### PR TITLE
Add dummy spec and fix RuboCop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-    - 'spec/integration/**/*'
   NewCops: enable
 
 Style/Documentation:
@@ -41,6 +40,10 @@ RSpec/HooksBeforeExamples:
 RSpec/ExampleLength:
   Exclude:
     - 'spec/**/*'
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/integration/**/*'
 
 Lint/EmptyClass:
   Exclude:

--- a/spec/fixtures/rails_app/app/models/user.rb
+++ b/spec/fixtures/rails_app/app/models/user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class User < ActiveRecord::Base
+  def self.column_names
+    %w[id name email created_at updated_at]
+  end
+end

--- a/spec/fixtures/rails_app/config/environment.rb
+++ b/spec/fixtures/rails_app/config/environment.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require_relative '../app/models/user'
+
+class ActionDispatch
+  class Routing
+    class RoutesInspector
+      def initialize(routes); end
+
+      def format(formatter, options)
+        <<~ROUTES
+          Prefix Verb URI Pattern Controller#Action
+          users GET /users(.:format) users#index
+        ROUTES
+      end
+    end
+  end
+end
+
+class Rails
+  def self.application
+    @application ||= Application.new
+  end
+
+  class Application
+    def routes
+      RouteCollection.new
+    end
+  end
+
+  class RouteCollection
+    def routes
+      []
+    end
+  end
+end

--- a/spec/fixtures/rails_app/config/routes.rb
+++ b/spec/fixtures/rails_app/config/routes.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.routes.draw do
+  resources :users
+end

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'spec_helper'
+require 'tmpdir'
+
+require 'awesome_annotate/model'
+require 'awesome_annotate/route'
+
+RSpec.describe 'Rails application annotation' do
+  let(:fixture_app_path) { File.expand_path('../fixtures/rails_app', __dir__) }
+
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp_r("#{fixture_app_path}/.", tmpdir)
+
+      Dir.chdir(tmpdir) do
+        example.run
+      end
+    end
+  end
+
+  it 'annotates a model file in a Rails-like application root' do
+    annotator = AwesomeAnnotate::Model.new
+
+    expect { 2.times { annotator.annotate('user') } }.to output(/annotate users table columns/).to_stdout
+
+    model_content = File.read('app/models/user.rb')
+    expect(model_content.scan('# == AwesomeAnnotate: columns').size).to eq 1
+    expect(model_content.scan('# == /AwesomeAnnotate: columns').size).to eq 1
+    expect(model_content).to include '# Columns: id, name, email, created_at, updated_at'
+    expect(model_content).to include 'class User < ActiveRecord::Base'
+  end
+
+  it 'annotates a routes file in a Rails-like application root' do
+    annotator = AwesomeAnnotate::Route.new
+
+    expect { 2.times { annotator.annotate } }.to output(%r{annotate routes in config/routes\.rb}).to_stdout
+
+    route_content = File.read('config/routes.rb')
+    expect(route_content.scan('# == AwesomeAnnotate: routes').size).to eq 1
+    expect(route_content.scan('# == /AwesomeAnnotate: routes').size).to eq 1
+    expect(route_content).to include '# users GET /users(.:format) users#index'
+    expect(route_content).to include 'Rails.application.routes.draw do'
+  end
+end


### PR DESCRIPTION
This pull request introduces an integration test suite for Rails application annotation and adds a minimal Rails-like app fixture for testing. It also updates RuboCop configuration to better handle the new integration tests and fixture files.

Testing improvements:

* Added a new integration spec, `rails_app_spec.rb`, which verifies that model and routes files in a Rails-like application are correctly annotated by the `AwesomeAnnotate` gem. The tests ensure idempotency and check for expected annotation markers and content.
* Added a minimal Rails-like fixture application under `spec/fixtures/rails_app` with sample model (`user.rb`), routes (`routes.rb`), and a stubbed Rails environment (`environment.rb`) to support integration testing. [[1]](diffhunk://#diff-ecd8cca5a4f904f6bcc2e6bd5dd741a66f8cf3de331b5a6866f420e41259bdb8R1-R7) [[2]](diffhunk://#diff-f99a55bb7f8c47a80071831679704a41774d4e6dcf9a6c4b68321a5881c3dc09R1-R5) [[3]](diffhunk://#diff-1e51ea42dc6966fb802399d2158ba6dd4ceaa8c35e70bc95d8dec96be5adc011R1-R37)

Rubocop configuration updates:

* Updated `.rubocop.yml` to exclude the new integration test files from certain cops, and moved the exclusion of `spec/integration/**/*` from `AllCops` to `RSpec/DescribeClass` to allow linting but skip specific RSpec rules for integration specs. [[1]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cL11) [[2]](diffhunk://#diff-4f894049af3375c2bd4e608f546f8d4a0eed95464efcdea850993200db9fef5cR44-R47)