### PR TITLE
Update model annotation schema and specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,21 @@ bundle exec awesome_annotate model user
 ```
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
-columns, and writes a block before the class definition in `app/models/user.rb`:
+columns, and writes a schema block before the class definition in
+`app/models/user.rb`:
 
 ```ruby
 # == AwesomeAnnotate: columns
-# Columns: id, name, email, created_at, updated_at
+# == Schema Information
+#
+# Table name: users
+#
+#  id         :integer  not null, primary key
+#  name       :string
+#  email      :string   not null, default("")
+#  created_at :datetime not null
+#  updated_at :datetime not null
+#
 # == /AwesomeAnnotate: columns
 class User < ApplicationRecord
 end
@@ -107,7 +117,9 @@ runs.
 
 ## Current Limitations
 
-- Only model column names and routes are supported.
+- Only model schema blocks and routes are supported.
+- Model annotations include column type, nullability, primary key, and default
+  values. Index information is not supported yet.
 - Model annotation currently targets files under `app/models`.
 - Model class detection expects a simple class declaration such as
   `class User < ApplicationRecord`.

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -28,10 +28,9 @@ module AwesomeAnnotate
 
       return say 'This model does not inherit activerecord' unless klass < ActiveRecord::Base
 
-      column_names = column_names(klass)
       file_path = model_file_path(model_name)
 
-      insert_file_before_class(file_path, "# Columns: #{column_names.join(', ')}\n")
+      insert_file_before_class(file_path, schema_annotation(klass))
 
       say "annotate #{model_name.pluralize} table columns in #{file_path}"
     end
@@ -51,8 +50,47 @@ module AwesomeAnnotate
       )
     end
 
-    def column_names(klass)
-      klass.column_names
+    def schema_annotation(klass)
+      columns = klass.columns
+      column_name_width = columns.map { |column| column.name.length }.max || 0
+      column_type_width = columns.map { |column| column_type(column).length }.max || 0
+
+      [
+        schema_header(klass),
+        columns.map { |column| column_annotation(klass, column, column_name_width, column_type_width) }.join,
+        "#\n"
+      ].join
+    end
+
+    def schema_header(klass)
+      [
+        "# == Schema Information\n",
+        "#\n",
+        "# Table name: #{klass.table_name}\n",
+        "#\n"
+      ].join
+    end
+
+    def column_annotation(klass, column, column_name_width, column_type_width)
+      column_name = column.name.ljust(column_name_width)
+      type = column_type(column).ljust(column_type_width)
+      details = column_details(klass, column)
+      line = "#  #{column_name} :#{type}"
+
+      line = "#{line} #{details.join(', ')}" if details.any?
+      "#{line}\n"
+    end
+
+    def column_type(column)
+      column.type.to_s
+    end
+
+    def column_details(klass, column)
+      details = []
+      details << 'not null' if column.null == false
+      details << 'primary key' if column.name == klass.primary_key
+      details << "default(#{column.default.inspect})" unless column.default.nil?
+      details
     end
 
     def model_file_path(model_name)

--- a/spec/fixtures/rails_app/app/models/user.rb
+++ b/spec/fixtures/rails_app/app/models/user.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
-  def self.column_names
-    %w[id name email created_at updated_at]
+  Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+
+  def self.columns
+    [
+      Column.new(name: 'id', type: :integer, null: false),
+      Column.new(name: 'name', type: :string, null: true),
+      Column.new(name: 'email', type: :string, null: false, default: ''),
+      Column.new(name: 'created_at', type: :datetime, null: false),
+      Column.new(name: 'updated_at', type: :datetime, null: false)
+    ]
+  end
+
+  def self.primary_key
+    'id'
+  end
+
+  def self.table_name
+    'users'
   end
 end

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe 'Rails application annotation' do
     model_content = File.read('app/models/user.rb')
     expect(model_content.scan('# == AwesomeAnnotate: columns').size).to eq 1
     expect(model_content.scan('# == /AwesomeAnnotate: columns').size).to eq 1
-    expect(model_content).to include '# Columns: id, name, email, created_at, updated_at'
+    expect(model_content).to include '# == Schema Information'
+    expect(model_content).to include '#  id         :integer  not null, primary key'
     expect(model_content).to include 'class User < ActiveRecord::Base'
   end
 

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -20,7 +20,10 @@ RSpec.describe AwesomeAnnotate::Model do
           file_content = File.read("#{model_dir}/user.rb")
           expect(file_content).to include '# == AwesomeAnnotate: columns'
           expect(file_content).to include '# == /AwesomeAnnotate: columns'
-          expect(file_content).to include 'Columns: id, name, email, created_at, updated_at'
+          expect(file_content).to include '# == Schema Information'
+          expect(file_content).to include '# Table name: users'
+          expect(file_content).to include '#  id         :integer  not null, primary key'
+          expect(file_content).to include '#  email      :string   not null, default("")'
         end
 
         it 'replaces existing annotate block' do
@@ -29,7 +32,7 @@ RSpec.describe AwesomeAnnotate::Model do
           file_content = File.read("#{model_dir}/user.rb")
           expect(file_content.scan('# == AwesomeAnnotate: columns').size).to eq 1
           expect(file_content.scan('# == /AwesomeAnnotate: columns').size).to eq 1
-          expect(file_content.scan('Columns: id, name, email, created_at, updated_at').size).to eq 1
+          expect(file_content.scan('# == Schema Information').size).to eq 1
         end
 
         after { file_reset("#{model_dir}/user.rb") }

--- a/spec/mock/model.rb
+++ b/spec/mock/model.rb
@@ -2,7 +2,7 @@
 
 module ActiveRecord
   class Base
-    def self.column_names
+    def self.columns
       []
     end
   end

--- a/spec/mock/user.rb
+++ b/spec/mock/user.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 class User < ActiveRecord::Base
-  def self.column_names
-    %w[id name email created_at updated_at]
+  Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+
+  def self.columns
+    [
+      Column.new(name: 'id', type: :integer, null: false),
+      Column.new(name: 'name', type: :string, null: true),
+      Column.new(name: 'email', type: :string, null: false, default: ''),
+      Column.new(name: 'created_at', type: :datetime, null: false),
+      Column.new(name: 'updated_at', type: :datetime, null: false)
+    ]
+  end
+
+  def self.primary_key
+    'id'
+  end
+
+  def self.table_name
+    'users'
   end
 end


### PR DESCRIPTION
This pull request updates the model annotation feature to generate a detailed schema block similar to Rails' standard schema comments. Instead of listing only column names, the annotation now includes column types, nullability, primary key, and default values. The implementation and tests have been updated to reflect this richer schema information.

**Model annotation improvements:**

* The annotation inserted before model class definitions now includes a "Schema Information" block detailing each column's name, type, nullability, primary key, and default value, replacing the previous simple column name list. (`lib/awesome_annotate/model.rb` [[1]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL31-R33) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL54-R93); `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R66) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R122)

**Test and mock updates:**

* Updated test fixtures and mocks to provide `columns` information (with type, null, and default attributes) instead of just `column_names`, ensuring tests validate the new annotation format. (`spec/fixtures/rails_app/app/models/user.rb` [[1]](diffhunk://#diff-ecd8cca5a4f904f6bcc2e6bd5dd741a66f8cf3de331b5a6866f420e41259bdb8L4-R21); `spec/mock/user.rb` [[2]](diffhunk://#diff-ecd8cca5a4f904f6bcc2e6bd5dd741a66f8cf3de331b5a6866f420e41259bdb8L4-R21); `spec/mock/model.rb` [[3]](diffhunk://#diff-118d9f75d1961bb2873dc364613424b2ea36d562ab2426c276186aac750411d9L5-R5)
* Adjusted integration and unit tests to check for the presence and correctness of the new schema block in model files. (`spec/integration/rails_app_spec.rb` [[1]](diffhunk://#diff-7aacd18f681946e5e7822553c359c36c501ff790ea287a94eecde32fd8e19f64L31-R32); `spec/lib/awesome_annotate/model_spec.rb` [[2]](diffhunk://#diff-f078b1b7861316532779aae9006c6bd38707a05117b3a693ebe87806ee0c2e8dL23-R26) [[3]](diffhunk://#diff-f078b1b7861316532779aae9006c6bd38707a05117b3a693ebe87806ee0c2e8dL32-R35)