### PR TITLE
Add model annotation index schema and specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ columns, and writes a schema block before the class definition in
 #  created_at :datetime not null
 #  updated_at :datetime not null
 #
+# Indexes
+#
+#  (email)       UNIQUE, index_users_on_email
+#  (name,email)  index_users_on_name_and_email
+#
 # == /AwesomeAnnotate: columns
 class User < ApplicationRecord
 end
@@ -119,7 +124,7 @@ runs.
 
 - Only model schema blocks and routes are supported.
 - Model annotations include column type, nullability, primary key, and default
-  values. Index information is not supported yet.
+  values, plus basic index information.
 - Model annotation currently targets files under `app/models`.
 - Model class detection expects a simple class declaration such as
   `class User < ApplicationRecord`.

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -5,12 +5,14 @@ require 'thor'
 require_relative 'annotation_block'
 require_relative 'error'
 require_relative 'rails_environment'
+require_relative 'schema_annotation'
 
 module AwesomeAnnotate
   class Model < Thor
     include AnnotationBlock
     include Thor::Actions
     include RailsEnvironment
+    include SchemaAnnotation
 
     def initialize(params = {})
       super()
@@ -48,49 +50,6 @@ module AwesomeAnnotate
         content: message,
         before: /^class\s+\w+\s+<\s+\w+/
       )
-    end
-
-    def schema_annotation(klass)
-      columns = klass.columns
-      column_name_width = columns.map { |column| column.name.length }.max || 0
-      column_type_width = columns.map { |column| column_type(column).length }.max || 0
-
-      [
-        schema_header(klass),
-        columns.map { |column| column_annotation(klass, column, column_name_width, column_type_width) }.join,
-        "#\n"
-      ].join
-    end
-
-    def schema_header(klass)
-      [
-        "# == Schema Information\n",
-        "#\n",
-        "# Table name: #{klass.table_name}\n",
-        "#\n"
-      ].join
-    end
-
-    def column_annotation(klass, column, column_name_width, column_type_width)
-      column_name = column.name.ljust(column_name_width)
-      type = column_type(column).ljust(column_type_width)
-      details = column_details(klass, column)
-      line = "#  #{column_name} :#{type}"
-
-      line = "#{line} #{details.join(', ')}" if details.any?
-      "#{line}\n"
-    end
-
-    def column_type(column)
-      column.type.to_s
-    end
-
-    def column_details(klass, column)
-      details = []
-      details << 'not null' if column.null == false
-      details << 'primary key' if column.name == klass.primary_key
-      details << "default(#{column.default.inspect})" unless column.default.nil?
-      details
     end
 
     def model_file_path(model_name)

--- a/lib/awesome_annotate/schema_annotation.rb
+++ b/lib/awesome_annotate/schema_annotation.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module AwesomeAnnotate
+  module SchemaAnnotation
+    private
+
+    def schema_annotation(klass)
+      columns = klass.columns
+      column_name_width = columns.map { |column| column.name.length }.max || 0
+      column_type_width = columns.map { |column| column_type(column).length }.max || 0
+
+      [
+        schema_header(klass),
+        columns.map { |column| column_annotation(klass, column, column_name_width, column_type_width) }.join,
+        index_annotations(klass),
+        "#\n"
+      ].join
+    end
+
+    def schema_header(klass)
+      [
+        "# == Schema Information\n",
+        "#\n",
+        "# Table name: #{klass.table_name}\n",
+        "#\n"
+      ].join
+    end
+
+    def column_annotation(klass, column, column_name_width, column_type_width)
+      column_name = column.name.ljust(column_name_width)
+      type = column_type(column).ljust(column_type_width)
+      details = column_details(klass, column)
+      line = "#  #{column_name} :#{type}"
+
+      line = "#{line} #{details.join(', ')}" if details.any?
+      "#{line}\n"
+    end
+
+    def column_type(column)
+      column.type.to_s
+    end
+
+    def column_details(klass, column)
+      details = []
+      details << 'not null' if column.null == false
+      details << 'primary key' if column.name == klass.primary_key
+      details << "default(#{column.default.inspect})" unless column.default.nil?
+      details
+    end
+
+    def index_annotations(klass)
+      indexes = klass.connection.indexes(klass.table_name)
+      return '' if indexes.empty?
+
+      index_column_width = indexes.map { |index| index_columns(index).length }.max || 0
+
+      [
+        "#\n",
+        "# Indexes\n",
+        "#\n",
+        indexes.map { |index| index_annotation(index, index_column_width) }.join
+      ].join
+    end
+
+    def index_annotation(index, index_column_width)
+      columns = index_columns(index).ljust(index_column_width)
+      details = index_details(index)
+
+      "#  #{columns}  #{details.join(', ')}\n"
+    end
+
+    def index_columns(index)
+      "(#{index.columns.join(',')})"
+    end
+
+    def index_details(index)
+      details = []
+      details << 'UNIQUE' if index.unique
+      details << index.name
+      details
+    end
+  end
+end

--- a/spec/fixtures/rails_app/app/models/user.rb
+++ b/spec/fixtures/rails_app/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ActiveRecord::Base
   Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+  Index = Struct.new(:columns, :unique, :name, keyword_init: true) unless const_defined?(:Index, false)
 
   def self.columns
     [
@@ -19,5 +20,18 @@ class User < ActiveRecord::Base
 
   def self.table_name
     'users'
+  end
+
+  def self.connection
+    Connection.new
+  end
+
+  class Connection
+    def indexes(_table_name)
+      [
+        Index.new(columns: ['email'], unique: true, name: 'index_users_on_email'),
+        Index.new(columns: %w[name email], unique: false, name: 'index_users_on_name_and_email')
+      ]
+    end
   end
 end

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Rails application annotation' do
     expect(model_content.scan('# == /AwesomeAnnotate: columns').size).to eq 1
     expect(model_content).to include '# == Schema Information'
     expect(model_content).to include '#  id         :integer  not null, primary key'
+    expect(model_content).to include '#  (email)       UNIQUE, index_users_on_email'
     expect(model_content).to include 'class User < ActiveRecord::Base'
   end
 

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe AwesomeAnnotate::Model do
           expect(file_content).to include '# Table name: users'
           expect(file_content).to include '#  id         :integer  not null, primary key'
           expect(file_content).to include '#  email      :string   not null, default("")'
+          expect(file_content).to include '# Indexes'
+          expect(file_content).to include '#  (email)       UNIQUE, index_users_on_email'
+          expect(file_content).to include '#  (name,email)  index_users_on_name_and_email'
         end
 
         it 'replaces existing annotate block' do

--- a/spec/mock/user.rb
+++ b/spec/mock/user.rb
@@ -2,6 +2,7 @@
 
 class User < ActiveRecord::Base
   Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+  Index = Struct.new(:columns, :unique, :name, keyword_init: true) unless const_defined?(:Index, false)
 
   def self.columns
     [
@@ -19,5 +20,18 @@ class User < ActiveRecord::Base
 
   def self.table_name
     'users'
+  end
+
+  def self.connection
+    Connection.new
+  end
+
+  class Connection
+    def indexes(_table_name)
+      [
+        Index.new(columns: ['email'], unique: true, name: 'index_users_on_email'),
+        Index.new(columns: %w[name email], unique: false, name: 'index_users_on_name_and_email')
+      ]
+    end
   end
 end


### PR DESCRIPTION
This pull request adds support for including index information in the schema annotation blocks for Rails models. Indexes are now displayed in the generated annotation, showing their columns, uniqueness, and names. The implementation is refactored to move schema annotation logic into a new module, and tests and documentation are updated accordingly.

**Schema annotation improvements:**

* Added index information (columns, uniqueness, and names) to the schema annotation block generated for models, both in the code and in the documentation. [[1]](diffhunk://#diff-2fc046f557825ee535aa21cabd356265a247dcefe3e1f71f81e0e15888ac8ce5R1-R83) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R67-R71) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L122-R127)
* Refactored schema annotation logic into a new `SchemaAnnotation` module for better separation of concerns and maintainability. [[1]](diffhunk://#diff-2fc046f557825ee535aa21cabd356265a247dcefe3e1f71f81e0e15888ac8ce5R1-R83) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eR8-R15) [[3]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL53-L95)

**Test and fixture updates:**

* Updated test fixtures (`spec/mock/user.rb`, `spec/fixtures/rails_app/app/models/user.rb`) to simulate index data and connection behavior for models. [[1]](diffhunk://#diff-ecd8cca5a4f904f6bcc2e6bd5dd741a66f8cf3de331b5a6866f420e41259bdb8R5) [[2]](diffhunk://#diff-ecd8cca5a4f904f6bcc2e6bd5dd741a66f8cf3de331b5a6866f420e41259bdb8R24-R36)
* Enhanced integration and unit tests to verify that index information appears correctly in the annotated model files. [[1]](diffhunk://#diff-7aacd18f681946e5e7822553c359c36c501ff790ea287a94eecde32fd8e19f64R33) [[2]](diffhunk://#diff-f078b1b7861316532779aae9006c6bd38707a05117b3a693ebe87806ee0c2e8dR27-R29)