### PR TITLE
Add command models and corresponding specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Annotate a model:
 bundle exec awesome_annotate model user
 ```
 
+Annotate all models:
+
+```sh
+bundle exec awesome_annotate models
+```
+
+Annotate specific models:
+
+```sh
+bundle exec awesome_annotate models user article admin/user
+```
+
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in
 `app/models/user.rb`:

--- a/lib/awesome_annotate/cli.rb
+++ b/lib/awesome_annotate/cli.rb
@@ -22,6 +22,11 @@ module AwesomeAnnotate
       AwesomeAnnotate::Model.new.annotate(model_name)
     end
 
+    desc 'models [model_names...]', 'annotate all models or specified models'
+    def models(*model_names)
+      AwesomeAnnotate::Model.new.annotate_all(model_names)
+    end
+
     map %w[routes -r] => :routes
     desc 'routes', 'Writes application route information to `config/routes.rb`.'
     def routes

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -25,7 +25,25 @@ module AwesomeAnnotate
       raise 'Rails application path is required' unless @env_file_path.exist?
 
       load_rails_environment
+      annotate_loaded_model(model_name)
+    end
 
+    desc 'models [model names]', 'annotate all models or specified models'
+    def annotate_all(model_names = [])
+      raise 'Rails application path is required' unless @env_file_path.exist?
+
+      load_rails_environment
+
+      if model_names.empty?
+        discover_model_names.each { |model_name| annotate_discovered_model(model_name) }
+      else
+        model_names.each { |model_name| annotate_loaded_model(model_name) }
+      end
+    end
+
+    private
+
+    def annotate_loaded_model(model_name)
       klass = klass_name(model_name)
 
       return say 'This model does not inherit activerecord' unless klass < ActiveRecord::Base
@@ -37,10 +55,28 @@ module AwesomeAnnotate
       say "annotate #{model_name.pluralize} table columns in #{file_path}"
     end
 
-    private
-
     def model_dir
       Pathname.new('app/models')
+    end
+
+    def discover_model_names
+      Dir.glob(@model_dir.join('**/*.rb')).filter_map do |file_path|
+        next if excluded_model_file?(file_path)
+
+        Pathname.new(file_path).relative_path_from(@model_dir).sub_ext('').to_s
+      end
+    end
+
+    def excluded_model_file?(file_path)
+      relative_path = Pathname.new(file_path).relative_path_from(@model_dir).to_s
+
+      relative_path == 'application_record.rb' || relative_path.start_with?('concerns/')
+    end
+
+    def annotate_discovered_model(model_name)
+      annotate_loaded_model(model_name)
+    rescue AwesomeAnnotate::NotFoundError
+      nil
     end
 
     def insert_file_before_class(file_path, message)

--- a/spec/fixtures/rails_app/app/models/application_record.rb
+++ b/spec/fixtures/rails_app/app/models/application_record.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+end

--- a/spec/fixtures/rails_app/app/models/article.rb
+++ b/spec/fixtures/rails_app/app/models/article.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Article < ActiveRecord::Base
+  Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+
+  def self.columns
+    [
+      Column.new(name: 'id', type: :integer, null: false),
+      Column.new(name: 'title', type: :string, null: false),
+      Column.new(name: 'published', type: :boolean, null: false, default: false)
+    ]
+  end
+
+  def self.primary_key
+    'id'
+  end
+
+  def self.table_name
+    'articles'
+  end
+
+  def self.connection
+    Connection.new
+  end
+
+  class Connection
+    def indexes(_table_name)
+      []
+    end
+  end
+end

--- a/spec/fixtures/rails_app/app/models/concerns/auditable.rb
+++ b/spec/fixtures/rails_app/app/models/concerns/auditable.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Auditable
+end

--- a/spec/fixtures/rails_app/config/environment.rb
+++ b/spec/fixtures/rails_app/config/environment.rb
@@ -2,6 +2,8 @@
 
 require 'active_record'
 require_relative '../app/models/user'
+require_relative '../app/models/article'
+require_relative '../app/models/application_record'
 
 class ActionDispatch
   class Routing

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -45,4 +45,22 @@ RSpec.describe 'Rails application annotation' do
     expect(route_content).to include '# users GET /users(.:format) users#index'
     expect(route_content).to include 'Rails.application.routes.draw do'
   end
+
+  it 'annotates discovered model files in a Rails-like application root' do
+    annotator = AwesomeAnnotate::Model.new
+
+    expect do
+      annotator.annotate_all
+    end.to output(/annotate articles table columns.*annotate users table columns/m).to_stdout
+
+    user_content = File.read('app/models/user.rb')
+    article_content = File.read('app/models/article.rb')
+    application_record_content = File.read('app/models/application_record.rb')
+    concern_content = File.read('app/models/concerns/auditable.rb')
+
+    expect(user_content).to include '# Table name: users'
+    expect(article_content).to include '# Table name: articles'
+    expect(application_record_content).not_to include '# == AwesomeAnnotate: columns'
+    expect(concern_content).not_to include '# == AwesomeAnnotate: columns'
+  end
 end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -9,4 +9,16 @@ RSpec.describe AwesomeAnnotate::CLI do
       expect { described_class.new.print_version }.to output("#{AwesomeAnnotate::VERSION}\n").to_stdout
     end
   end
+
+  describe '#models' do
+    it 'delegates model names to model annotator' do
+      annotator = instance_double(AwesomeAnnotate::Model)
+      allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
+      allow(annotator).to receive(:annotate_all)
+
+      described_class.new.models('user', 'article')
+
+      expect(annotator).to have_received(:annotate_all).with(%w[user article])
+    end
+  end
 end

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -62,4 +62,45 @@ RSpec.describe AwesomeAnnotate::Model do
       end
     end
   end
+
+  describe '#annotate_all' do
+    context 'when model names are specified' do
+      it 'annotates specified models only' do
+        expect do
+          annotate_model.annotate_all(%w[user])
+        end.to output(%r{annotate users table columns in spec/mock/user\.rb}).to_stdout
+
+        user_content = File.read("#{model_dir}/user.rb")
+        article_content = File.read("#{model_dir}/article.rb")
+
+        expect(user_content).to include '# Table name: users'
+        expect(article_content).not_to include '# == AwesomeAnnotate: columns'
+      end
+
+      after { file_reset("#{model_dir}/user.rb") }
+    end
+
+    context 'when model names are not specified' do
+      it 'discovers and annotates all model files' do
+        expect do
+          annotate_model.annotate_all
+        end.to output(/annotate articles table columns.*annotate users table columns/m).to_stdout
+
+        user_content = File.read("#{model_dir}/user.rb")
+        article_content = File.read("#{model_dir}/article.rb")
+        application_record_content = File.read("#{model_dir}/application_record.rb")
+        concern_content = File.read("#{model_dir}/concerns/auditable.rb")
+
+        expect(user_content).to include '# Table name: users'
+        expect(article_content).to include '# Table name: articles'
+        expect(application_record_content).not_to include '# == AwesomeAnnotate: columns'
+        expect(concern_content).not_to include '# == AwesomeAnnotate: columns'
+      end
+
+      after do
+        file_reset("#{model_dir}/user.rb")
+        file_reset("#{model_dir}/article.rb")
+      end
+    end
+  end
 end

--- a/spec/mock/application_record.rb
+++ b/spec/mock/application_record.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+end

--- a/spec/mock/article.rb
+++ b/spec/mock/article.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Article < ActiveRecord::Base
+  Column = Struct.new(:name, :type, :null, :default, keyword_init: true) unless const_defined?(:Column, false)
+
+  def self.columns
+    [
+      Column.new(name: 'id', type: :integer, null: false),
+      Column.new(name: 'title', type: :string, null: false),
+      Column.new(name: 'published', type: :boolean, null: false, default: false)
+    ]
+  end
+
+  def self.primary_key
+    'id'
+  end
+
+  def self.table_name
+    'articles'
+  end
+
+  def self.connection
+    Connection.new
+  end
+
+  class Connection
+    def indexes(_table_name)
+      []
+    end
+  end
+end

--- a/spec/mock/concerns/auditable.rb
+++ b/spec/mock/concerns/auditable.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Auditable
+end

--- a/spec/mock/config.rb
+++ b/spec/mock/config.rb
@@ -4,3 +4,5 @@ puts 'config file loaded'
 
 require_relative 'model'
 require_relative 'user'
+require_relative 'article'
+require_relative 'application_record'


### PR DESCRIPTION
This pull request adds support for annotating all models or specific models in a Rails project with a single command, and updates the documentation and tests accordingly. The main changes introduce a new CLI command, implement model discovery (excluding concerns and `application_record.rb`), and ensure comprehensive test coverage for the new functionality.

**New annotation features:**

* Added a new CLI command `models` to annotate all models or a specified list of models via `bundle exec awesome_annotate models [model_names...]` (`lib/awesome_annotate/cli.rb`, `README.md`). [[1]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057R25-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51-R62)
* Implemented `annotate_all` in `AwesomeAnnotate::Model`, which discovers model files (excluding concerns and `application_record.rb`) and annotates them, or annotates only specified models if arguments are provided (`lib/awesome_annotate/model.rb`). [[1]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eR28-R46) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL40-R81)

**Documentation updates:**

* Updated the `README.md` to document the new `models` command and its usage examples.

**Test improvements:**

* Added and updated integration and unit tests to verify annotation of all models, exclusion of concerns and `application_record.rb`, and correct CLI delegation (`spec/integration/rails_app_spec.rb`, `spec/lib/awesome_annotate/model_spec.rb`, `spec/lib/awesome_annotate/cli_spec.rb`). [[1]](diffhunk://#diff-7aacd18f681946e5e7822553c359c36c501ff790ea287a94eecde32fd8e19f64R48-R65) [[2]](diffhunk://#diff-f078b1b7861316532779aae9006c6bd38707a05117b3a693ebe87806ee0c2e8dR65-R105) [[3]](diffhunk://#diff-ecf2dc556c20d6e1808f8057e6cd9ece937946aae2aa65e30dbb3d0d3cb80c28R12-R23)
* Updated fixture and mock files to include new model files and ensure proper test coverage (`spec/fixtures/rails_app/app/models/article.rb`, `spec/fixtures/rails_app/app/models/application_record.rb`, `spec/fixtures/rails_app/app/models/concerns/auditable.rb`, `spec/mock/article.rb`, `spec/mock/application_record.rb`, `spec/mock/concerns/auditable.rb`, `spec/fixtures/rails_app/config/environment.rb`, `spec/mock/config.rb`). [[1]](diffhunk://#diff-02cde5fa4b852c34099bebc0c3c6f9075346d5e78edae5e73f8eedbb480339abR1-R31) [[2]](diffhunk://#diff-6cab350d7ef070066fe6caaf6a084108da3f64a1bd99cdb3d38f10ed2009f034R1-R4) [[3]](diffhunk://#diff-a70ec227614b33b34c5516f2cbfb2ed2b7be5a0ffb75d352e6354ecca5389719R1-R4) [[4]](diffhunk://#diff-1e51ea42dc6966fb802399d2158ba6dd4ceaa8c35e70bc95d8dec96be5adc011R5-R6) [[5]](diffhunk://#diff-783a8235a44fc30c9a9d4404814f0d809c859671ed19a74ea1922686a7add677R7-R8)