### PR TITLE
Add all command functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Annotate specific models:
 bundle exec awesome_annotate models user article admin/user
 ```
 
+Annotate all models and routes:
+
+```sh
+bundle exec awesome_annotate all
+```
+
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in
 `app/models/user.rb`:

--- a/lib/awesome_annotate/cli.rb
+++ b/lib/awesome_annotate/cli.rb
@@ -33,6 +33,12 @@ module AwesomeAnnotate
       AwesomeAnnotate::Route.new.annotate
     end
 
+    desc 'all', 'annotate all models and routes'
+    def all
+      AwesomeAnnotate::Model.new.annotate_all
+      AwesomeAnnotate::Route.new.annotate
+    end
+
     def self.exit_on_failure?
       true
     end

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -63,4 +63,18 @@ RSpec.describe 'Rails application annotation' do
     expect(application_record_content).not_to include '# == AwesomeAnnotate: columns'
     expect(concern_content).not_to include '# == AwesomeAnnotate: columns'
   end
+
+  it 'annotates all models and routes in a Rails-like application root' do
+    expect do
+      AwesomeAnnotate::CLI.new.all
+    end.to output(/annotate articles table columns.*annotate users table columns.*annotate routes/m).to_stdout
+
+    user_content = File.read('app/models/user.rb')
+    article_content = File.read('app/models/article.rb')
+    route_content = File.read('config/routes.rb')
+
+    expect(user_content).to include '# Table name: users'
+    expect(article_content).to include '# Table name: articles'
+    expect(route_content).to include '# == AwesomeAnnotate: routes'
+  end
 end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -21,4 +21,20 @@ RSpec.describe AwesomeAnnotate::CLI do
       expect(annotator).to have_received(:annotate_all).with(%w[user article])
     end
   end
+
+  describe '#all' do
+    it 'annotates all models and routes' do
+      model_annotator = instance_double(AwesomeAnnotate::Model)
+      route_annotator = instance_double(AwesomeAnnotate::Route)
+      allow(AwesomeAnnotate::Model).to receive(:new).and_return(model_annotator)
+      allow(AwesomeAnnotate::Route).to receive(:new).and_return(route_annotator)
+      allow(model_annotator).to receive(:annotate_all)
+      allow(route_annotator).to receive(:annotate)
+
+      described_class.new.all
+
+      expect(model_annotator).to have_received(:annotate_all)
+      expect(route_annotator).to have_received(:annotate)
+    end
+  end
 end


### PR DESCRIPTION
This pull request introduces a new feature that allows users to annotate all models and routes in a Rails application with a single command. It adds a new CLI command, updates documentation, and provides comprehensive test coverage for the new functionality.

**New CLI Feature: Annotate All Models and Routes**

* Added a new `all` command to the CLI (`lib/awesome_annotate/cli.rb`) that annotates all models and routes in one step.
* Updated the documentation in `README.md` to describe the new `all` command and provide usage examples.

**Test Coverage**

* Added integration tests to verify that the `all` command annotates all models and routes as expected in a Rails-like application. (`spec/integration/rails_app_spec.rb`)
* Added unit tests for the CLI to ensure that the new `all` command correctly orchestrates model and route annotation. (`spec/lib/awesome_annotate/cli_spec.rb`)