### PR TITLE
Add remove command and its specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Annotate all models and routes:
 bundle exec awesome_annotate all
 ```
 
+Remove generated annotations:
+
+```sh
+bundle exec awesome_annotate remove model user
+bundle exec awesome_annotate remove models
+bundle exec awesome_annotate remove routes
+bundle exec awesome_annotate remove all
+```
+
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in
 `app/models/user.rb`:

--- a/lib/awesome_annotate/annotation_block.rb
+++ b/lib/awesome_annotate/annotation_block.rb
@@ -12,6 +12,17 @@ module AwesomeAnnotate
       File.write(path, replace_annotation(file_content, marker, annotation, before))
     end
 
+    def remove_annotation(file_path:, marker:)
+      path = file_path.to_s
+      file_content = File.read(path)
+      pattern = annotation_block_pattern(marker)
+
+      return false unless file_content.match?(pattern)
+
+      File.write(path, file_content.gsub(pattern, ''))
+      true
+    end
+
     def annotation_block(marker, content)
       body = content.end_with?("\n") ? content : "#{content}\n"
 

--- a/lib/awesome_annotate/cli.rb
+++ b/lib/awesome_annotate/cli.rb
@@ -7,6 +7,29 @@ require 'awesome_annotate/version'
 require 'thor'
 
 module AwesomeAnnotate
+  class Remove < Thor
+    desc 'model [model_name]', 'remove annotation from a model'
+    def model(model_name)
+      AwesomeAnnotate::Model.new.remove(model_name)
+    end
+
+    desc 'models [model_names...]', 'remove annotations from all models or specified models'
+    def models(*model_names)
+      AwesomeAnnotate::Model.new.remove_all(model_names)
+    end
+
+    desc 'routes', 'remove annotation from `config/routes.rb`'
+    def routes
+      AwesomeAnnotate::Route.new.remove
+    end
+
+    desc 'all', 'remove annotations from all models and routes'
+    def all
+      AwesomeAnnotate::Model.new.remove_all
+      AwesomeAnnotate::Route.new.remove
+    end
+  end
+
   class CLI < Thor
     include Thor::Actions
 
@@ -38,6 +61,9 @@ module AwesomeAnnotate
       AwesomeAnnotate::Model.new.annotate_all
       AwesomeAnnotate::Route.new.annotate
     end
+
+    desc 'remove SUBCOMMAND', 'remove generated annotations'
+    subcommand 'remove', Remove
 
     def self.exit_on_failure?
       true

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -41,10 +41,26 @@ module AwesomeAnnotate
       end
     end
 
+    desc 'remove [model name]', 'remove annotation from your model'
+    def remove(model_name)
+      file_path = model_file_path(model_name)
+
+      remove_model_annotation(file_path)
+    end
+
+    desc 'remove_all [model names]', 'remove annotations from all models or specified models'
+    def remove_all(model_names = [])
+      if model_names.empty?
+        discovered_model_file_paths.each { |file_path| remove_model_annotation(file_path, report_missing: false) }
+      else
+        model_names.each { |model_name| remove(model_name) }
+      end
+    end
+
     private
 
-    def annotate_loaded_model(model_name)
-      klass = klass_name(model_name)
+    def annotate_loaded_model(model_name, report_missing: true)
+      klass = klass_name(model_name, report_missing: report_missing)
 
       return say 'This model does not inherit activerecord' unless klass < ActiveRecord::Base
 
@@ -55,16 +71,16 @@ module AwesomeAnnotate
       say "annotate #{model_name.pluralize} table columns in #{file_path}"
     end
 
-    def model_dir
-      Pathname.new('app/models')
+    def discover_model_names
+      discovered_model_file_paths.map { |file_path| model_name_from_file_path(file_path) }
     end
 
-    def discover_model_names
-      Dir.glob(@model_dir.join('**/*.rb')).filter_map do |file_path|
-        next if excluded_model_file?(file_path)
+    def discovered_model_file_paths
+      Dir.glob(@model_dir.join('**/*.rb')).reject { |file_path| excluded_model_file?(file_path) }
+    end
 
-        Pathname.new(file_path).relative_path_from(@model_dir).sub_ext('').to_s
-      end
+    def model_name_from_file_path(file_path)
+      Pathname.new(file_path).relative_path_from(@model_dir).sub_ext('').to_s
     end
 
     def excluded_model_file?(file_path)
@@ -74,9 +90,17 @@ module AwesomeAnnotate
     end
 
     def annotate_discovered_model(model_name)
-      annotate_loaded_model(model_name)
+      annotate_loaded_model(model_name, report_missing: false)
     rescue AwesomeAnnotate::NotFoundError
       nil
+    end
+
+    def remove_model_annotation(file_path, report_missing: true)
+      if remove_annotation(file_path: file_path, marker: 'columns')
+        say "remove model annotation in #{file_path}"
+      elsif report_missing
+        say "no model annotation in #{file_path}"
+      end
     end
 
     def insert_file_before_class(file_path, message)
@@ -99,11 +123,11 @@ module AwesomeAnnotate
       file_path
     end
 
-    def klass_name(model_name)
+    def klass_name(model_name, report_missing: true)
       name = model_name.singularize.camelize
       Object.const_get(name)
     rescue NameError
-      say 'Model not found'
+      say 'Model not found' if report_missing
       raise AwesomeAnnotate::NotFoundError
     end
 

--- a/lib/awesome_annotate/route.rb
+++ b/lib/awesome_annotate/route.rb
@@ -36,6 +36,17 @@ module AwesomeAnnotate
       say "annotate routes in #{@route_file_path}"
     end
 
+    desc 'remove', 'remove route annotation'
+    def remove
+      raise 'Route file not found' unless @route_file_path.exist?
+
+      if remove_annotation(file_path: @route_file_path, marker: 'routes')
+        say "remove route annotation in #{@route_file_path}"
+      else
+        say "no route annotation in #{@route_file_path}"
+      end
+    end
+
     private
 
     def parse_routes(routes)

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -77,4 +77,22 @@ RSpec.describe 'Rails application annotation' do
     expect(article_content).to include '# Table name: articles'
     expect(route_content).to include '# == AwesomeAnnotate: routes'
   end
+
+  it 'removes all model and route annotations in a Rails-like application root' do
+    expect do
+      AwesomeAnnotate::CLI.new.all
+    end.to output(/annotate articles table columns.*annotate users table columns.*annotate routes/m).to_stdout
+
+    expect do
+      AwesomeAnnotate::CLI.start(%w[remove all])
+    end.to output(/remove model annotation.*remove route annotation/m).to_stdout
+
+    user_content = File.read('app/models/user.rb')
+    article_content = File.read('app/models/article.rb')
+    route_content = File.read('config/routes.rb')
+
+    expect(user_content).not_to include '# == AwesomeAnnotate: columns'
+    expect(article_content).not_to include '# == AwesomeAnnotate: columns'
+    expect(route_content).not_to include '# == AwesomeAnnotate: routes'
+  end
 end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -37,4 +37,20 @@ RSpec.describe AwesomeAnnotate::CLI do
       expect(route_annotator).to have_received(:annotate)
     end
   end
+
+  describe 'AwesomeAnnotate::Remove#all' do
+    it 'removes all model and route annotations' do
+      model_annotator = instance_double(AwesomeAnnotate::Model)
+      route_annotator = instance_double(AwesomeAnnotate::Route)
+      allow(AwesomeAnnotate::Model).to receive(:new).and_return(model_annotator)
+      allow(AwesomeAnnotate::Route).to receive(:new).and_return(route_annotator)
+      allow(model_annotator).to receive(:remove_all)
+      allow(route_annotator).to receive(:remove)
+
+      AwesomeAnnotate::Remove.new.all
+
+      expect(model_annotator).to have_received(:remove_all)
+      expect(route_annotator).to have_received(:remove)
+    end
+  end
 end

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -103,4 +103,36 @@ RSpec.describe AwesomeAnnotate::Model do
       end
     end
   end
+
+  describe '#remove' do
+    it 'removes annotation from a model file' do
+      expect { annotate_model.annotate('user') }.to output(/annotate users table columns/).to_stdout
+
+      expect { annotate_model.remove('user') }.to output(%r{remove model annotation in spec/mock/user\.rb}).to_stdout
+
+      file_content = File.read("#{model_dir}/user.rb")
+      expect(file_content).not_to include '# == AwesomeAnnotate: columns'
+      expect(file_content).to include 'class User < ActiveRecord::Base'
+    end
+  end
+
+  describe '#remove_all' do
+    it 'removes annotations from discovered model files' do
+      expect do
+        annotate_model.annotate_all
+      end.to output(/annotate articles table columns.*annotate users table columns/m).to_stdout
+
+      expect do
+        annotate_model.remove_all
+      end.to output(
+        %r{remove model annotation in spec/mock/article\.rb.*remove model annotation in spec/mock/user\.rb}m
+      ).to_stdout
+
+      user_content = File.read("#{model_dir}/user.rb")
+      article_content = File.read("#{model_dir}/article.rb")
+
+      expect(user_content).not_to include '# == AwesomeAnnotate: columns'
+      expect(article_content).not_to include '# == AwesomeAnnotate: columns'
+    end
+  end
 end

--- a/spec/lib/awesome_annotate/route_spec.rb
+++ b/spec/lib/awesome_annotate/route_spec.rb
@@ -69,4 +69,19 @@ RSpec.describe AwesomeAnnotate::Route do
       end
     end
   end
+
+  describe '#remove' do
+    it 'removes annotation from routes file' do
+      route_mock(routes_message)
+      expect { annotate_model.annotate }.to output(/annotate routes/).to_stdout
+
+      expect { annotate_model.remove }.to output(%r{remove route annotation in spec/mock/routes\.rb}).to_stdout
+
+      file_content = File.read(route_file_path)
+      expect(file_content).not_to include '# == AwesomeAnnotate: routes'
+      expect(file_content).to include 'Rails.application.routes.draw do'
+    end
+
+    after { file_reset(route_file_path) }
+  end
 end


### PR DESCRIPTION
This pull request adds support for removing generated annotations from models and routes in the AwesomeAnnotate gem. It introduces new CLI commands for removing annotations, updates the documentation, and includes comprehensive tests to ensure the removal functionality works as expected.

**New CLI commands for removing annotations:**

* Added a `remove` subcommand with options to remove annotations from a single model, multiple models, all models, routes, or everything at once via the CLI (`lib/awesome_annotate/cli.rb`, `lib/awesome_annotate/model.rb`, `lib/awesome_annotate/route.rb`) [[1]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057R10-R32) [[2]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057R65-R67) [[3]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eR44-R63) [[4]](diffhunk://#diff-3a2deaf175160ffb476ff95e93a2bc71686d193b1e88d0e2e86307db2fd3985cR39-R49).

**Implementation of annotation removal:**

* Implemented `remove_annotation` logic for both model and route files, including handling for missing annotations and reporting results to the user (`lib/awesome_annotate/annotation_block.rb`, `lib/awesome_annotate/model.rb`, `lib/awesome_annotate/route.rb`) [[1]](diffhunk://#diff-eb3ff95f9499b079ab90968c800dc83314551588c7972facef49dab3ae05ad51R15-R25) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL77-R105) [[3]](diffhunk://#diff-3a2deaf175160ffb476ff95e93a2bc71686d193b1e88d0e2e86307db2fd3985cR39-R49).

**Documentation updates:**

* Updated the `README.md` with instructions and examples for removing generated annotations using the new CLI commands.

**Testing improvements:**

* Added integration and unit tests to verify that annotation removal works for models and routes, and that the CLI outputs correct messages (`spec/integration/rails_app_spec.rb`, `spec/lib/awesome_annotate/cli_spec.rb`, `spec/lib/awesome_annotate/model_spec.rb`, `spec/lib/awesome_annotate/route_spec.rb`) [[1]](diffhunk://#diff-7aacd18f681946e5e7822553c359c36c501ff790ea287a94eecde32fd8e19f64R80-R97) [[2]](diffhunk://#diff-ecf2dc556c20d6e1808f8057e6cd9ece937946aae2aa65e30dbb3d0d3cb80c28R40-R55) [[3]](diffhunk://#diff-f078b1b7861316532779aae9006c6bd38707a05117b3a693ebe87806ee0c2e8dR106-R137) [[4]](diffhunk://#diff-89b99e2efdbfff69176c3fd80f0b8b8fed41d723a7003dd3a91f631e70e25bbdR72-R86).

**Refactoring and minor improvements:**

* Refactored model discovery and annotation logic for better maintainability and consistency in handling file paths and reporting (`lib/awesome_annotate/model.rb`) [[1]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL58-L68) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL102-R130).