### PR TITLE
Add black line formatting and RSpec configuration

### DIFF
--- a/lib/awesome_annotate/annotation_block.rb
+++ b/lib/awesome_annotate/annotation_block.rb
@@ -28,12 +28,12 @@ module AwesomeAnnotate
 
       "# == AwesomeAnnotate: #{marker}\n" \
         "#{body}" \
-        "# == /AwesomeAnnotate: #{marker}\n"
+        "# == /AwesomeAnnotate: #{marker}\n\n"
     end
 
     def annotation_block_pattern(marker)
       escaped_marker = Regexp.escape(marker)
-      %r{^# == AwesomeAnnotate: #{escaped_marker}\n.*?^# == /AwesomeAnnotate: #{escaped_marker}\n}m
+      %r{^# == AwesomeAnnotate: #{escaped_marker}\n.*?^# == /AwesomeAnnotate: #{escaped_marker}\n(?:\n)*}m
     end
 
     def replace_annotation(file_content, marker, annotation, before)

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe AwesomeAnnotate::Model do
           expect(file_content).to include '# Indexes'
           expect(file_content).to include '#  (email)       UNIQUE, index_users_on_email'
           expect(file_content).to include '#  (name,email)  index_users_on_name_and_email'
+          expect(file_content).to include "# == /AwesomeAnnotate: columns\n\nclass User < ActiveRecord::Base"
         end
 
         it 'replaces existing annotate block' do

--- a/spec/lib/awesome_annotate/route_spec.rb
+++ b/spec/lib/awesome_annotate/route_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe AwesomeAnnotate::Route do
           expect(file_content).to include '# == AwesomeAnnotate: routes'
           expect(file_content).to include '# == /AwesomeAnnotate: routes'
           expect(file_content).to include parse_routes(routes_message)
+          expect(file_content).to include "# == /AwesomeAnnotate: routes\n\nRails.application.routes.draw do"
         end
 
         it 'replaces existing annotate block' do

--- a/spec/support/file_reset.rb
+++ b/spec/support/file_reset.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FileReset
-  ANNOTATION_BLOCK_PATTERN = %r{^# == AwesomeAnnotate: [^\n]*\n.*?^# == /AwesomeAnnotate: [^\n]*\n}m
+  ANNOTATION_BLOCK_PATTERN = %r{^# == AwesomeAnnotate: [^\n]*\n.*?^# == /AwesomeAnnotate: [^\n]*\n(?:\n)*}m
 
   def file_reset(file_path)
     content = File.read(file_path)


### PR DESCRIPTION
This pull request updates the annotation block formatting in the `awesome_annotate` gem to ensure that annotation blocks are consistently followed by a blank line. It also updates related regular expressions and tests to match this new format.

Formatting and pattern changes:

* Updated the annotation block generator in `annotation_block.rb` to add a blank line after the closing annotation marker, and adjusted the regular expression used to match annotation blocks to account for possible trailing newlines.
* Updated the annotation block pattern in `spec/support/file_reset.rb` to match the new format with potential trailing blank lines.

Test updates:

* Updated model annotation tests in `model_spec.rb` to expect a blank line after the closing annotation marker.
* Updated route annotation tests in `route_spec.rb` to expect a blank line after the closing annotation marker.