### PR TITLE
Add configuration options and update related documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ annotation_position: top
 exclude_model_files: []
 include_indexes: true
 exclude_columns: []
+include_column_defaults: true
 ```
 
 When this file exists, annotation and removal commands use these values. This
@@ -119,7 +120,8 @@ change command behavior without passing Ruby options directly. Set
 are inserted. Set `exclude_model_files` to relative file paths or glob patterns
 under `model_dir` to skip them during model discovery. Set `include_indexes` to
 `false` to omit the Indexes section from model schema annotations. Set
-`exclude_columns` to column names to omit them from model schema annotations.
+`exclude_columns` to column names to omit them from model schema annotations. Set
+`include_column_defaults` to `false` to omit `default(...)` details.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ route_file_path: config/routes.rb
 annotation_position: top
 exclude_model_files: []
 include_indexes: true
+exclude_columns: []
 ```
 
 When this file exists, annotation and removal commands use these values. This
@@ -117,7 +118,8 @@ change command behavior without passing Ruby options directly. Set
 `annotation_position` to `top` or `bottom` to choose where new annotation blocks
 are inserted. Set `exclude_model_files` to relative file paths or glob patterns
 under `model_dir` to skip them during model discovery. Set `include_indexes` to
-`false` to omit the Indexes section from model schema annotations.
+`false` to omit the Indexes section from model schema annotations. Set
+`exclude_columns` to column names to omit them from model schema annotations.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -107,13 +107,15 @@ env_file_path: config/environment.rb
 model_dir: app/models
 route_file_path: config/routes.rb
 annotation_position: top
+exclude_model_files: []
 ```
 
 When this file exists, annotation and removal commands use these values. This
 allows applications with non-standard model, route, or environment file paths to
 change command behavior without passing Ruby options directly. Set
 `annotation_position` to `top` or `bottom` to choose where new annotation blocks
-are inserted.
+are inserted. Set `exclude_model_files` to relative file paths or glob patterns
+under `model_dir` to skip them during model discovery.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ model_dir: app/models
 route_file_path: config/routes.rb
 annotation_position: top
 exclude_model_files: []
+include_indexes: true
 ```
 
 When this file exists, annotation and removal commands use these values. This
@@ -115,7 +116,8 @@ allows applications with non-standard model, route, or environment file paths to
 change command behavior without passing Ruby options directly. Set
 `annotation_position` to `top` or `bottom` to choose where new annotation blocks
 are inserted. Set `exclude_model_files` to relative file paths or glob patterns
-under `model_dir` to skip them during model discovery.
+under `model_dir` to skip them during model discovery. Set `include_indexes` to
+`false` to omit the Indexes section from model schema annotations.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ bundle exec awesome_annotate models
 bundle exec awesome_annotate models user article admin/user
 bundle exec awesome_annotate routes
 bundle exec awesome_annotate all
+bundle exec awesome_annotate init
 bundle exec awesome_annotate remove model user
 bundle exec awesome_annotate remove models
 bundle exec awesome_annotate remove routes
@@ -89,6 +90,27 @@ bundle exec awesome_annotate remove models
 bundle exec awesome_annotate remove routes
 bundle exec awesome_annotate remove all
 ```
+
+Create a configuration file:
+
+```sh
+bundle exec awesome_annotate init
+```
+
+This creates `config/initializers/awesome_annotate.yml`:
+
+```yaml
+# AwesomeAnnotate configuration
+#
+# Change these paths when your Rails app uses non-standard locations.
+env_file_path: config/environment.rb
+model_dir: app/models
+route_file_path: config/routes.rb
+```
+
+When this file exists, annotation and removal commands use these values. This
+allows applications with non-standard model, route, or environment file paths to
+change command behavior without passing Ruby options directly.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ exclude_model_files: []
 include_indexes: true
 exclude_columns: []
 include_column_defaults: true
+exclude_routes: []
 ```
 
 When this file exists, annotation and removal commands use these values. This
@@ -121,7 +122,8 @@ are inserted. Set `exclude_model_files` to relative file paths or glob patterns
 under `model_dir` to skip them during model discovery. Set `include_indexes` to
 `false` to omit the Indexes section from model schema annotations. Set
 `exclude_columns` to column names to omit them from model schema annotations. Set
-`include_column_defaults` to `false` to omit `default(...)` details.
+`include_column_defaults` to `false` to omit `default(...)` details. Set
+`exclude_routes` to route line patterns to omit them from route annotations.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/README.md
+++ b/README.md
@@ -106,11 +106,14 @@ This creates `config/initializers/awesome_annotate.yml`:
 env_file_path: config/environment.rb
 model_dir: app/models
 route_file_path: config/routes.rb
+annotation_position: top
 ```
 
 When this file exists, annotation and removal commands use these values. This
 allows applications with non-standard model, route, or environment file paths to
-change command behavior without passing Ruby options directly.
+change command behavior without passing Ruby options directly. Set
+`annotation_position` to `top` or `bottom` to choose where new annotation blocks
+are inserted.
 
 This loads `config/environment.rb`, resolves `User`, reads its Active Record
 columns, and writes a schema block before the class definition in

--- a/lib/awesome_annotate.rb
+++ b/lib/awesome_annotate.rb
@@ -2,4 +2,5 @@
 
 require_relative 'awesome_annotate/version'
 require_relative 'awesome_annotate/error'
+require_relative 'awesome_annotate/configuration'
 require_relative 'awesome_annotate/cli'

--- a/lib/awesome_annotate/annotation_block.rb
+++ b/lib/awesome_annotate/annotation_block.rb
@@ -4,12 +4,12 @@ module AwesomeAnnotate
   module AnnotationBlock
     private
 
-    def replace_or_insert_annotation(file_path:, marker:, content:, before:)
+    def replace_or_insert_annotation(file_path:, marker:, content:, before:, position: 'top')
       path = file_path.to_s
       file_content = File.read(path)
       annotation = annotation_block(marker, content)
 
-      File.write(path, replace_annotation(file_content, marker, annotation, before))
+      File.write(path, replace_annotation(file_content, marker, annotation, before, position))
     end
 
     def remove_annotation(file_path:, marker:)
@@ -36,10 +36,12 @@ module AwesomeAnnotate
       %r{^# == AwesomeAnnotate: #{escaped_marker}\n.*?^# == /AwesomeAnnotate: #{escaped_marker}\n(?:\n)*}m
     end
 
-    def replace_annotation(file_content, marker, annotation, before)
+    def replace_annotation(file_content, marker, annotation, before, position)
       pattern = annotation_block_pattern(marker)
 
       return file_content.sub(pattern, annotation) if file_content.match?(pattern)
+
+      return "#{file_content.chomp}\n#{annotation}" if position.to_s == 'bottom'
 
       file_content.sub(before, "#{annotation}\\0")
     end

--- a/lib/awesome_annotate/cli.rb
+++ b/lib/awesome_annotate/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'awesome_annotate'
+require 'awesome_annotate/configuration'
 require 'awesome_annotate/model'
 require 'awesome_annotate/route'
 require 'awesome_annotate/version'
@@ -10,23 +11,37 @@ module AwesomeAnnotate
   class Remove < Thor
     desc 'model [model_name]', 'remove annotation from a model'
     def model(model_name)
-      AwesomeAnnotate::Model.new.remove(model_name)
+      model_annotator.remove(model_name)
     end
 
     desc 'models [model_names...]', 'remove annotations from all models or specified models'
     def models(*model_names)
-      AwesomeAnnotate::Model.new.remove_all(model_names)
+      model_annotator.remove_all(model_names)
     end
 
     desc 'routes', 'remove annotation from `config/routes.rb`'
     def routes
-      AwesomeAnnotate::Route.new.remove
+      route_annotator.remove
     end
 
     desc 'all', 'remove annotations from all models and routes'
     def all
-      AwesomeAnnotate::Model.new.remove_all
-      AwesomeAnnotate::Route.new.remove
+      model_annotator.remove_all
+      route_annotator.remove
+    end
+
+    private
+
+    def model_annotator
+      AwesomeAnnotate::Model.new(configuration.options)
+    end
+
+    def route_annotator
+      AwesomeAnnotate::Route.new(configuration.options)
+    end
+
+    def configuration
+      AwesomeAnnotate::Configuration.load
     end
   end
 
@@ -42,24 +57,35 @@ module AwesomeAnnotate
     map %w[model -m] => :model
     desc 'model [model_name]', 'annotate your model'
     def model(model_name)
-      AwesomeAnnotate::Model.new.annotate(model_name)
+      model_annotator.annotate(model_name)
     end
 
     desc 'models [model_names...]', 'annotate all models or specified models'
     def models(*model_names)
-      AwesomeAnnotate::Model.new.annotate_all(model_names)
+      model_annotator.annotate_all(model_names)
     end
 
     map %w[routes -r] => :routes
     desc 'routes', 'Writes application route information to `config/routes.rb`.'
     def routes
-      AwesomeAnnotate::Route.new.annotate
+      route_annotator.annotate
     end
 
     desc 'all', 'annotate all models and routes'
     def all
-      AwesomeAnnotate::Model.new.annotate_all
-      AwesomeAnnotate::Route.new.annotate
+      model_annotator.annotate_all
+      route_annotator.annotate
+    end
+
+    desc 'init', "create #{AwesomeAnnotate::Configuration::DEFAULT_PATH}"
+    def init
+      path = AwesomeAnnotate::Configuration::DEFAULT_PATH
+      if File.exist?(path)
+        say "Config file already exists: #{path}"
+      else
+        AwesomeAnnotate::Configuration.create(path)
+        say "create #{path}"
+      end
     end
 
     desc 'remove SUBCOMMAND', 'remove generated annotations'
@@ -67,6 +93,20 @@ module AwesomeAnnotate
 
     def self.exit_on_failure?
       true
+    end
+
+    private
+
+    def model_annotator
+      AwesomeAnnotate::Model.new(configuration.options)
+    end
+
+    def route_annotator
+      AwesomeAnnotate::Route.new(configuration.options)
+    end
+
+    def configuration
+      AwesomeAnnotate::Configuration.load
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -13,7 +13,8 @@ module AwesomeAnnotate
       annotation_position: 'top',
       exclude_model_files: [],
       include_indexes: true,
-      exclude_columns: []
+      exclude_columns: [],
+      include_column_defaults: true
     }.freeze
     ANNOTATION_POSITIONS = %w[top bottom].freeze
 
@@ -28,6 +29,7 @@ module AwesomeAnnotate
       exclude_model_files: []
       include_indexes: true
       exclude_columns: []
+      include_column_defaults: true
     YAML
 
     class << self
@@ -63,6 +65,7 @@ module AwesomeAnnotate
       validate_exclude_model_files
       validate_include_indexes
       validate_exclude_columns
+      validate_include_column_defaults
     end
 
     private
@@ -89,6 +92,12 @@ module AwesomeAnnotate
       return if @options[:exclude_columns].is_a?(Array)
 
       raise ArgumentError, 'exclude_columns must be an array'
+    end
+
+    def validate_include_column_defaults
+      return if [true, false].include?(@options[:include_column_defaults])
+
+      raise ArgumentError, 'include_column_defaults must be true or false'
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -14,7 +14,8 @@ module AwesomeAnnotate
       exclude_model_files: [],
       include_indexes: true,
       exclude_columns: [],
-      include_column_defaults: true
+      include_column_defaults: true,
+      exclude_routes: []
     }.freeze
     ANNOTATION_POSITIONS = %w[top bottom].freeze
 
@@ -30,6 +31,7 @@ module AwesomeAnnotate
       include_indexes: true
       exclude_columns: []
       include_column_defaults: true
+      exclude_routes: []
     YAML
 
     class << self
@@ -66,6 +68,7 @@ module AwesomeAnnotate
       validate_include_indexes
       validate_exclude_columns
       validate_include_column_defaults
+      validate_exclude_routes
     end
 
     private
@@ -98,6 +101,12 @@ module AwesomeAnnotate
       return if [true, false].include?(@options[:include_column_defaults])
 
       raise ArgumentError, 'include_column_defaults must be true or false'
+    end
+
+    def validate_exclude_routes
+      return if @options[:exclude_routes].is_a?(Array)
+
+      raise ArgumentError, 'exclude_routes must be an array'
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'yaml'
+
+module AwesomeAnnotate
+  class Configuration
+    DEFAULT_PATH = 'config/initializers/awesome_annotate.yml'
+    DEFAULT_OPTIONS = {
+      env_file_path: 'config/environment.rb',
+      model_dir: 'app/models',
+      route_file_path: 'config/routes.rb'
+    }.freeze
+
+    TEMPLATE = <<~YAML
+      # AwesomeAnnotate configuration
+      #
+      # Change these paths when your Rails app uses non-standard locations.
+      env_file_path: config/environment.rb
+      model_dir: app/models
+      route_file_path: config/routes.rb
+    YAML
+
+    class << self
+      def load(path = DEFAULT_PATH)
+        return new unless File.exist?(path)
+
+        loaded = YAML.safe_load_file(path, aliases: false) || {}
+        raise ArgumentError, "Configuration file must contain a YAML mapping: #{path}" unless loaded.is_a?(Hash)
+
+        new(symbolize_options(loaded))
+      end
+
+      def create(path = DEFAULT_PATH)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, TEMPLATE)
+      end
+
+      private
+
+      def symbolize_options(options)
+        options.each_with_object({}) do |(key, value), result|
+          symbol_key = key.to_sym
+          result[symbol_key] = value if DEFAULT_OPTIONS.key?(symbol_key)
+        end
+      end
+    end
+
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = DEFAULT_OPTIONS.merge(options)
+    end
+  end
+end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -11,7 +11,8 @@ module AwesomeAnnotate
       model_dir: 'app/models',
       route_file_path: 'config/routes.rb',
       annotation_position: 'top',
-      exclude_model_files: []
+      exclude_model_files: [],
+      include_indexes: true
     }.freeze
     ANNOTATION_POSITIONS = %w[top bottom].freeze
 
@@ -24,6 +25,7 @@ module AwesomeAnnotate
       route_file_path: config/routes.rb
       annotation_position: top
       exclude_model_files: []
+      include_indexes: true
     YAML
 
     class << self
@@ -57,6 +59,7 @@ module AwesomeAnnotate
       @options = DEFAULT_OPTIONS.merge(options)
       validate_annotation_position
       validate_exclude_model_files
+      validate_include_indexes
     end
 
     private
@@ -71,6 +74,12 @@ module AwesomeAnnotate
       return if @options[:exclude_model_files].is_a?(Array)
 
       raise ArgumentError, 'exclude_model_files must be an array'
+    end
+
+    def validate_include_indexes
+      return if [true, false].include?(@options[:include_indexes])
+
+      raise ArgumentError, 'include_indexes must be true or false'
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -9,8 +9,10 @@ module AwesomeAnnotate
     DEFAULT_OPTIONS = {
       env_file_path: 'config/environment.rb',
       model_dir: 'app/models',
-      route_file_path: 'config/routes.rb'
+      route_file_path: 'config/routes.rb',
+      annotation_position: 'top'
     }.freeze
+    ANNOTATION_POSITIONS = %w[top bottom].freeze
 
     TEMPLATE = <<~YAML
       # AwesomeAnnotate configuration
@@ -19,6 +21,7 @@ module AwesomeAnnotate
       env_file_path: config/environment.rb
       model_dir: app/models
       route_file_path: config/routes.rb
+      annotation_position: top
     YAML
 
     class << self
@@ -50,6 +53,15 @@ module AwesomeAnnotate
 
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
+      validate_annotation_position
+    end
+
+    private
+
+    def validate_annotation_position
+      return if ANNOTATION_POSITIONS.include?(@options[:annotation_position])
+
+      raise ArgumentError, "annotation_position must be one of: #{ANNOTATION_POSITIONS.join(', ')}"
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -10,7 +10,8 @@ module AwesomeAnnotate
       env_file_path: 'config/environment.rb',
       model_dir: 'app/models',
       route_file_path: 'config/routes.rb',
-      annotation_position: 'top'
+      annotation_position: 'top',
+      exclude_model_files: []
     }.freeze
     ANNOTATION_POSITIONS = %w[top bottom].freeze
 
@@ -22,6 +23,7 @@ module AwesomeAnnotate
       model_dir: app/models
       route_file_path: config/routes.rb
       annotation_position: top
+      exclude_model_files: []
     YAML
 
     class << self
@@ -54,6 +56,7 @@ module AwesomeAnnotate
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
       validate_annotation_position
+      validate_exclude_model_files
     end
 
     private
@@ -62,6 +65,12 @@ module AwesomeAnnotate
       return if ANNOTATION_POSITIONS.include?(@options[:annotation_position])
 
       raise ArgumentError, "annotation_position must be one of: #{ANNOTATION_POSITIONS.join(', ')}"
+    end
+
+    def validate_exclude_model_files
+      return if @options[:exclude_model_files].is_a?(Array)
+
+      raise ArgumentError, 'exclude_model_files must be an array'
     end
   end
 end

--- a/lib/awesome_annotate/configuration.rb
+++ b/lib/awesome_annotate/configuration.rb
@@ -12,7 +12,8 @@ module AwesomeAnnotate
       route_file_path: 'config/routes.rb',
       annotation_position: 'top',
       exclude_model_files: [],
-      include_indexes: true
+      include_indexes: true,
+      exclude_columns: []
     }.freeze
     ANNOTATION_POSITIONS = %w[top bottom].freeze
 
@@ -26,6 +27,7 @@ module AwesomeAnnotate
       annotation_position: top
       exclude_model_files: []
       include_indexes: true
+      exclude_columns: []
     YAML
 
     class << self
@@ -60,6 +62,7 @@ module AwesomeAnnotate
       validate_annotation_position
       validate_exclude_model_files
       validate_include_indexes
+      validate_exclude_columns
     end
 
     private
@@ -80,6 +83,12 @@ module AwesomeAnnotate
       return if [true, false].include?(@options[:include_indexes])
 
       raise ArgumentError, 'include_indexes must be true or false'
+    end
+
+    def validate_exclude_columns
+      return if @options[:exclude_columns].is_a?(Array)
+
+      raise ArgumentError, 'exclude_columns must be an array'
     end
   end
 end

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -22,6 +22,7 @@ module AwesomeAnnotate
       @exclude_model_files = params[:exclude_model_files] || []
       @include_indexes = params.fetch(:include_indexes, true)
       @exclude_columns = params[:exclude_columns] || []
+      @include_column_defaults = params.fetch(:include_column_defaults, true)
     end
 
     desc 'model [model name]', 'annotate your model'
@@ -79,9 +80,7 @@ module AwesomeAnnotate
       discovered_model_file_paths.map { |file_path| model_name_from_file_path(file_path) }
     end
 
-    def discovered_model_file_paths
-      Dir.glob(@model_dir.join('**/*.rb')).reject { |file_path| excluded_model_file?(file_path) }
-    end
+    def discovered_model_file_paths = Dir.glob(@model_dir.join('**/*.rb')).reject { |path| excluded_model_file?(path) }
 
     def model_name_from_file_path(file_path)
       Pathname.new(file_path).relative_path_from(@model_dir).sub_ext('').to_s

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -20,6 +20,7 @@ module AwesomeAnnotate
       @model_dir = Pathname.new(params[:model_dir] || 'app/models')
       @annotation_position = params[:annotation_position] || 'top'
       @exclude_model_files = params[:exclude_model_files] || []
+      @include_indexes = params.fetch(:include_indexes, true)
     end
 
     desc 'model [model name]', 'annotate your model'

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -21,6 +21,7 @@ module AwesomeAnnotate
       @annotation_position = params[:annotation_position] || 'top'
       @exclude_model_files = params[:exclude_model_files] || []
       @include_indexes = params.fetch(:include_indexes, true)
+      @exclude_columns = params[:exclude_columns] || []
     end
 
     desc 'model [model name]', 'annotate your model'

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -19,6 +19,7 @@ module AwesomeAnnotate
       @env_file_path = Pathname.new(params[:env_file_path] || 'config/environment.rb')
       @model_dir = Pathname.new(params[:model_dir] || 'app/models')
       @annotation_position = params[:annotation_position] || 'top'
+      @exclude_model_files = params[:exclude_model_files] || []
     end
 
     desc 'model [model name]', 'annotate your model'
@@ -87,7 +88,12 @@ module AwesomeAnnotate
     def excluded_model_file?(file_path)
       relative_path = Pathname.new(file_path).relative_path_from(@model_dir).to_s
 
-      relative_path == 'application_record.rb' || relative_path.start_with?('concerns/')
+      relative_path == 'application_record.rb' || relative_path.start_with?('concerns/') ||
+        excluded_by_config?(relative_path)
+    end
+
+    def excluded_by_config?(relative_path)
+      @exclude_model_files.any? { |pattern| File.fnmatch?(pattern, relative_path, File::FNM_PATHNAME) }
     end
 
     def annotate_discovered_model(model_name)
@@ -105,13 +111,8 @@ module AwesomeAnnotate
     end
 
     def insert_file_before_class(file_path, message)
-      replace_or_insert_annotation(
-        file_path: file_path,
-        marker: 'columns',
-        content: message,
-        before: /^class\s+\w+\s+<\s+\w+/,
-        position: @annotation_position
-      )
+      replace_or_insert_annotation(file_path: file_path, marker: 'columns', content: message,
+                                   before: /^class\s+\w+\s+<\s+\w+/, position: @annotation_position)
     end
 
     def model_file_path(model_name)
@@ -133,9 +134,8 @@ module AwesomeAnnotate
       raise AwesomeAnnotate::NotFoundError
     end
 
-    def self.source_root
-      Dir.pwd
-    end
+    def self.source_root = Dir.pwd
+
     private_class_method :source_root
   end
 end

--- a/lib/awesome_annotate/model.rb
+++ b/lib/awesome_annotate/model.rb
@@ -18,6 +18,7 @@ module AwesomeAnnotate
       super()
       @env_file_path = Pathname.new(params[:env_file_path] || 'config/environment.rb')
       @model_dir = Pathname.new(params[:model_dir] || 'app/models')
+      @annotation_position = params[:annotation_position] || 'top'
     end
 
     desc 'model [model name]', 'annotate your model'
@@ -108,7 +109,8 @@ module AwesomeAnnotate
         file_path: file_path,
         marker: 'columns',
         content: message,
-        before: /^class\s+\w+\s+<\s+\w+/
+        before: /^class\s+\w+\s+<\s+\w+/,
+        position: @annotation_position
       )
     end
 

--- a/lib/awesome_annotate/route.rb
+++ b/lib/awesome_annotate/route.rb
@@ -16,6 +16,7 @@ module AwesomeAnnotate
       @env_file_path = Pathname.new(params[:env_file_path] || 'config/environment.rb')
       @route_file_path = Pathname.new(params[:route_file_path] || 'config/routes.rb')
       @annotation_position = params[:annotation_position] || 'top'
+      @exclude_routes = params[:exclude_routes] || []
     end
 
     desc 'annotate all routes', 'annotate your routes'
@@ -51,13 +52,17 @@ module AwesomeAnnotate
     private
 
     def parse_routes(routes)
-      split_routes = routes.split(/\r\n|\r|\n/)
+      split_routes = routes.split(/\r\n|\r|\n/).reject { |route| excluded_route?(route) }
       parse_routes = split_routes.map do |route|
         "# #{route}\n"
       end
       parse_routes.push("\n")
       parse_routes.unshift("#---This is route annotate---\n#\n")
       parse_routes.join
+    end
+
+    def excluded_route?(route)
+      @exclude_routes.any? { |pattern| File.fnmatch?(pattern, route.strip) }
     end
 
     def insert_file_before_class(file_path, message)

--- a/lib/awesome_annotate/route.rb
+++ b/lib/awesome_annotate/route.rb
@@ -15,6 +15,7 @@ module AwesomeAnnotate
       super()
       @env_file_path = Pathname.new(params[:env_file_path] || 'config/environment.rb')
       @route_file_path = Pathname.new(params[:route_file_path] || 'config/routes.rb')
+      @annotation_position = params[:annotation_position] || 'top'
     end
 
     desc 'annotate all routes', 'annotate your routes'
@@ -64,7 +65,8 @@ module AwesomeAnnotate
         file_path: file_path,
         marker: 'routes',
         content: message,
-        before: "Rails.application.routes.draw do\n"
+        before: "Rails.application.routes.draw do\n",
+        position: @annotation_position
       )
     end
 

--- a/lib/awesome_annotate/schema_annotation.rb
+++ b/lib/awesome_annotate/schema_annotation.rb
@@ -6,15 +6,17 @@ module AwesomeAnnotate
 
     def schema_annotation(klass)
       columns = klass.columns
-      column_name_width = columns.map { |column| column.name.length }.max || 0
-      column_type_width = columns.map { |column| column_type(column).length }.max || 0
 
       [
         schema_header(klass),
-        columns.map { |column| column_annotation(klass, column, column_name_width, column_type_width) }.join,
-        index_annotations(klass),
+        column_annotations(klass, columns),
+        include_indexes? ? index_annotations(klass) : '',
         "#\n"
       ].join
+    end
+
+    def include_indexes?
+      @include_indexes != false
     end
 
     def schema_header(klass)
@@ -24,6 +26,13 @@ module AwesomeAnnotate
         "# Table name: #{klass.table_name}\n",
         "#\n"
       ].join
+    end
+
+    def column_annotations(klass, columns)
+      column_name_width = columns.map { |column| column.name.length }.max || 0
+      column_type_width = columns.map { |column| column_type(column).length }.max || 0
+
+      columns.map { |column| column_annotation(klass, column, column_name_width, column_type_width) }.join
     end
 
     def column_annotation(klass, column, column_name_width, column_type_width)

--- a/lib/awesome_annotate/schema_annotation.rb
+++ b/lib/awesome_annotate/schema_annotation.rb
@@ -5,7 +5,7 @@ module AwesomeAnnotate
     private
 
     def schema_annotation(klass)
-      columns = klass.columns
+      columns = schema_columns(klass)
 
       [
         schema_header(klass),
@@ -17,6 +17,10 @@ module AwesomeAnnotate
 
     def include_indexes?
       @include_indexes != false
+    end
+
+    def schema_columns(klass)
+      klass.columns.reject { |column| @exclude_columns.include?(column.name) }
     end
 
     def schema_header(klass)

--- a/lib/awesome_annotate/schema_annotation.rb
+++ b/lib/awesome_annotate/schema_annotation.rb
@@ -19,6 +19,10 @@ module AwesomeAnnotate
       @include_indexes != false
     end
 
+    def include_column_defaults?
+      @include_column_defaults != false
+    end
+
     def schema_columns(klass)
       klass.columns.reject { |column| @exclude_columns.include?(column.name) }
     end
@@ -57,7 +61,7 @@ module AwesomeAnnotate
       details = []
       details << 'not null' if column.null == false
       details << 'primary key' if column.name == klass.primary_key
-      details << "default(#{column.default.inspect})" unless column.default.nil?
+      details << "default(#{column.default.inspect})" if include_column_defaults? && !column.default.nil?
       details
     end
 

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             exclude_columns:
               - email
             include_column_defaults: false
+            exclude_routes:
+              - '*private_policy*'
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -51,7 +53,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             exclude_model_files: ['article.rb'],
             include_indexes: false,
             exclude_columns: ['email'],
-            include_column_defaults: false
+            include_column_defaults: false,
+            exclude_routes: ['*private_policy*']
           )
         end
       end
@@ -67,7 +70,7 @@ RSpec.describe AwesomeAnnotate::CLI do
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
           expect(File.read('config/initializers/awesome_annotate.yml')).to include(
-            'include_column_defaults: true'
+            'exclude_routes: []'
           )
         end
       end
@@ -139,7 +142,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             exclude_model_files: [],
             include_indexes: true,
             exclude_columns: [],
-            include_column_defaults: true
+            include_column_defaults: true,
+            exclude_routes: []
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
@@ -149,7 +153,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             exclude_model_files: [],
             include_indexes: true,
             exclude_columns: [],
-            include_column_defaults: true
+            include_column_defaults: true,
+            exclude_routes: []
           )
         end
       end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             exclude_model_files:
               - article.rb
             include_indexes: false
+            exclude_columns:
+              - email
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -46,7 +48,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             route_file_path: 'spec/mock/routes.rb',
             annotation_position: 'bottom',
             exclude_model_files: ['article.rb'],
-            include_indexes: false
+            include_indexes: false,
+            exclude_columns: ['email']
           )
         end
       end
@@ -61,7 +64,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             described_class.new.init
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
-          expect(File.read('config/initializers/awesome_annotate.yml')).to include('include_indexes: true')
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include('exclude_columns: []')
         end
       end
     end
@@ -130,7 +133,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             route_file_path: 'config/routes.rb',
             annotation_position: 'top',
             exclude_model_files: [],
-            include_indexes: true
+            include_indexes: true,
+            exclude_columns: []
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
@@ -138,7 +142,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             route_file_path: 'config/routes.rb',
             annotation_position: 'top',
             exclude_model_files: [],
-            include_indexes: true
+            include_indexes: true,
+            exclude_columns: []
           )
         end
       end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             annotation_position: bottom
             exclude_model_files:
               - article.rb
+            include_indexes: false
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -44,7 +45,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             model_dir: 'spec/mock',
             route_file_path: 'spec/mock/routes.rb',
             annotation_position: 'bottom',
-            exclude_model_files: ['article.rb']
+            exclude_model_files: ['article.rb'],
+            include_indexes: false
           )
         end
       end
@@ -59,7 +61,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             described_class.new.init
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
-          expect(File.read('config/initializers/awesome_annotate.yml')).to include('exclude_model_files: []')
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include('include_indexes: true')
         end
       end
     end
@@ -127,14 +129,16 @@ RSpec.describe AwesomeAnnotate::CLI do
             model_dir: 'spec/mock',
             route_file_path: 'config/routes.rb',
             annotation_position: 'top',
-            exclude_model_files: []
+            exclude_model_files: [],
+            include_indexes: true
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
             model_dir: 'spec/mock',
             route_file_path: 'config/routes.rb',
             annotation_position: 'top',
-            exclude_model_files: []
+            exclude_model_files: [],
+            include_indexes: true
           )
         end
       end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             model_dir: spec/mock
             route_file_path: spec/mock/routes.rb
             annotation_position: bottom
+            exclude_model_files:
+              - article.rb
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -41,7 +43,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             env_file_path: 'spec/mock/config.rb',
             model_dir: 'spec/mock',
             route_file_path: 'spec/mock/routes.rb',
-            annotation_position: 'bottom'
+            annotation_position: 'bottom',
+            exclude_model_files: ['article.rb']
           )
         end
       end
@@ -56,7 +59,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             described_class.new.init
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
-          expect(File.read('config/initializers/awesome_annotate.yml')).to include('annotation_position: top')
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include('exclude_model_files: []')
         end
       end
     end
@@ -123,13 +126,15 @@ RSpec.describe AwesomeAnnotate::CLI do
             env_file_path: 'config/environment.rb',
             model_dir: 'spec/mock',
             route_file_path: 'config/routes.rb',
-            annotation_position: 'top'
+            annotation_position: 'top',
+            exclude_model_files: []
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
             model_dir: 'spec/mock',
             route_file_path: 'config/routes.rb',
-            annotation_position: 'top'
+            annotation_position: 'top',
+            exclude_model_files: []
           )
         end
       end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             include_indexes: false
             exclude_columns:
               - email
+            include_column_defaults: false
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -49,7 +50,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             annotation_position: 'bottom',
             exclude_model_files: ['article.rb'],
             include_indexes: false,
-            exclude_columns: ['email']
+            exclude_columns: ['email'],
+            include_column_defaults: false
           )
         end
       end
@@ -64,7 +66,9 @@ RSpec.describe AwesomeAnnotate::CLI do
             described_class.new.init
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
-          expect(File.read('config/initializers/awesome_annotate.yml')).to include('exclude_columns: []')
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include(
+            'include_column_defaults: true'
+          )
         end
       end
     end
@@ -134,7 +138,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             annotation_position: 'top',
             exclude_model_files: [],
             include_indexes: true,
-            exclude_columns: []
+            exclude_columns: [],
+            include_column_defaults: true
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
@@ -143,7 +148,8 @@ RSpec.describe AwesomeAnnotate::CLI do
             annotation_position: 'top',
             exclude_model_files: [],
             include_indexes: true,
-            exclude_columns: []
+            exclude_columns: [],
+            include_column_defaults: true
           )
         end
       end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -2,6 +2,7 @@
 
 require 'awesome_annotate/cli'
 require 'active_record'
+require 'tmpdir'
 
 RSpec.describe AwesomeAnnotate::CLI do
   describe '#print_version' do
@@ -19,6 +20,57 @@ RSpec.describe AwesomeAnnotate::CLI do
       described_class.new.models('user', 'article')
 
       expect(annotator).to have_received(:annotate_all).with(%w[user article])
+    end
+
+    it 'passes config options to the model annotator' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          FileUtils.mkdir_p('config/initializers')
+          File.write('config/initializers/awesome_annotate.yml', <<~YAML)
+            env_file_path: spec/mock/config.rb
+            model_dir: spec/mock
+            route_file_path: spec/mock/routes.rb
+          YAML
+          annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
+          allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
+
+          described_class.new.models('user')
+
+          expect(AwesomeAnnotate::Model).to have_received(:new).with(
+            env_file_path: 'spec/mock/config.rb',
+            model_dir: 'spec/mock',
+            route_file_path: 'spec/mock/routes.rb'
+          )
+        end
+      end
+    end
+  end
+
+  describe '#init' do
+    it 'creates a config file' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          expect do
+            described_class.new.init
+          end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
+
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include('route_file_path: config/routes.rb')
+        end
+      end
+    end
+
+    it 'does not overwrite an existing config file' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          FileUtils.mkdir_p('config/initializers')
+          File.write('config/initializers/awesome_annotate.yml', "model_dir: custom/models\n")
+
+          expect { described_class.new.init }.to output(
+            "Config file already exists: config/initializers/awesome_annotate.yml\n"
+          ).to_stdout
+          expect(File.read('config/initializers/awesome_annotate.yml')).to eq("model_dir: custom/models\n")
+        end
+      end
     end
   end
 
@@ -51,6 +103,32 @@ RSpec.describe AwesomeAnnotate::CLI do
 
       expect(model_annotator).to have_received(:remove_all)
       expect(route_annotator).to have_received(:remove)
+    end
+
+    it 'passes config options to remove annotators' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          FileUtils.mkdir_p('config/initializers')
+          File.write('config/initializers/awesome_annotate.yml', "model_dir: spec/mock\n")
+          model_annotator = instance_double(AwesomeAnnotate::Model, remove_all: nil)
+          route_annotator = instance_double(AwesomeAnnotate::Route, remove: nil)
+          allow(AwesomeAnnotate::Model).to receive(:new).and_return(model_annotator)
+          allow(AwesomeAnnotate::Route).to receive(:new).and_return(route_annotator)
+
+          AwesomeAnnotate::Remove.new.all
+
+          expect(AwesomeAnnotate::Model).to have_received(:new).with(
+            env_file_path: 'config/environment.rb',
+            model_dir: 'spec/mock',
+            route_file_path: 'config/routes.rb'
+          )
+          expect(AwesomeAnnotate::Route).to have_received(:new).with(
+            env_file_path: 'config/environment.rb',
+            model_dir: 'spec/mock',
+            route_file_path: 'config/routes.rb'
+          )
+        end
+      end
     end
   end
 end

--- a/spec/lib/awesome_annotate/cli_spec.rb
+++ b/spec/lib/awesome_annotate/cli_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             env_file_path: spec/mock/config.rb
             model_dir: spec/mock
             route_file_path: spec/mock/routes.rb
+            annotation_position: bottom
           YAML
           annotator = instance_double(AwesomeAnnotate::Model, annotate_all: nil)
           allow(AwesomeAnnotate::Model).to receive(:new).and_return(annotator)
@@ -39,7 +40,8 @@ RSpec.describe AwesomeAnnotate::CLI do
           expect(AwesomeAnnotate::Model).to have_received(:new).with(
             env_file_path: 'spec/mock/config.rb',
             model_dir: 'spec/mock',
-            route_file_path: 'spec/mock/routes.rb'
+            route_file_path: 'spec/mock/routes.rb',
+            annotation_position: 'bottom'
           )
         end
       end
@@ -54,7 +56,7 @@ RSpec.describe AwesomeAnnotate::CLI do
             described_class.new.init
           end.to output("create config/initializers/awesome_annotate.yml\n").to_stdout
 
-          expect(File.read('config/initializers/awesome_annotate.yml')).to include('route_file_path: config/routes.rb')
+          expect(File.read('config/initializers/awesome_annotate.yml')).to include('annotation_position: top')
         end
       end
     end
@@ -120,12 +122,14 @@ RSpec.describe AwesomeAnnotate::CLI do
           expect(AwesomeAnnotate::Model).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
             model_dir: 'spec/mock',
-            route_file_path: 'config/routes.rb'
+            route_file_path: 'config/routes.rb',
+            annotation_position: 'top'
           )
           expect(AwesomeAnnotate::Route).to have_received(:new).with(
             env_file_path: 'config/environment.rb',
             model_dir: 'spec/mock',
-            route_file_path: 'config/routes.rb'
+            route_file_path: 'config/routes.rb',
+            annotation_position: 'top'
           )
         end
       end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         route_file_path: 'config/routes.rb',
         annotation_position: 'top',
         exclude_model_files: [],
-        include_indexes: true
+        include_indexes: true,
+        exclude_columns: []
       )
     end
 
@@ -30,6 +31,9 @@ RSpec.describe AwesomeAnnotate::Configuration do
             - article.rb
             - legacy/*
           include_indexes: false
+          exclude_columns:
+            - encrypted_password
+            - reset_password_token
           unknown_option: ignored
         YAML
 
@@ -41,7 +45,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
           route_file_path: 'spec/mock/routes.rb',
           annotation_position: 'bottom',
           exclude_model_files: ['article.rb', 'legacy/*'],
-          include_indexes: false
+          include_indexes: false,
+          exclude_columns: %w[encrypted_password reset_password_token]
         )
       end
     end
@@ -93,6 +98,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when exclude_columns is not an array' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "exclude_columns: encrypted_password\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'exclude_columns must be an array'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -106,6 +123,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
         expect(content).to include('annotation_position: top')
         expect(content).to include('exclude_model_files: []')
         expect(content).to include('include_indexes: true')
+        expect(content).to include('exclude_columns: []')
       end
     end
   end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe AwesomeAnnotate::Configuration do
+  describe '.load' do
+    it 'returns default options when the config file does not exist' do
+      config = described_class.load('missing.yml')
+
+      expect(config.options).to eq(
+        env_file_path: 'config/environment.rb',
+        model_dir: 'app/models',
+        route_file_path: 'config/routes.rb'
+      )
+    end
+
+    it 'loads supported options from a YAML config file' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, <<~YAML)
+          env_file_path: spec/mock/config.rb
+          model_dir: spec/mock
+          route_file_path: spec/mock/routes.rb
+          unknown_option: ignored
+        YAML
+
+        config = described_class.load(path)
+
+        expect(config.options).to eq(
+          env_file_path: 'spec/mock/config.rb',
+          model_dir: 'spec/mock',
+          route_file_path: 'spec/mock/routes.rb'
+        )
+      end
+    end
+
+    it 'raises when the config file is not a YAML mapping' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "- value\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          "Configuration file must contain a YAML mapping: #{path}"
+        )
+      end
+    end
+  end
+
+  describe '.create' do
+    it 'creates a default config file' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'config/initializers/awesome_annotate.yml')
+
+        described_class.create(path)
+
+        expect(File.read(path)).to include('model_dir: app/models')
+      end
+    end
+  end
+end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         annotation_position: 'top',
         exclude_model_files: [],
         include_indexes: true,
-        exclude_columns: []
+        exclude_columns: [],
+        include_column_defaults: true
       )
     end
 
@@ -34,6 +35,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
           exclude_columns:
             - encrypted_password
             - reset_password_token
+          include_column_defaults: false
           unknown_option: ignored
         YAML
 
@@ -46,7 +48,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
           annotation_position: 'bottom',
           exclude_model_files: ['article.rb', 'legacy/*'],
           include_indexes: false,
-          exclude_columns: %w[encrypted_password reset_password_token]
+          exclude_columns: %w[encrypted_password reset_password_token],
+          include_column_defaults: false
         )
       end
     end
@@ -110,6 +113,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when include_column_defaults is not a boolean' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "include_column_defaults: maybe\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'include_column_defaults must be true or false'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -124,6 +139,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
         expect(content).to include('exclude_model_files: []')
         expect(content).to include('include_indexes: true')
         expect(content).to include('exclude_columns: []')
+        expect(content).to include('include_column_defaults: true')
       end
     end
   end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         model_dir: 'app/models',
         route_file_path: 'config/routes.rb',
         annotation_position: 'top',
-        exclude_model_files: []
+        exclude_model_files: [],
+        include_indexes: true
       )
     end
 
@@ -28,6 +29,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
           exclude_model_files:
             - article.rb
             - legacy/*
+          include_indexes: false
           unknown_option: ignored
         YAML
 
@@ -38,7 +40,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
           model_dir: 'spec/mock',
           route_file_path: 'spec/mock/routes.rb',
           annotation_position: 'bottom',
-          exclude_model_files: ['article.rb', 'legacy/*']
+          exclude_model_files: ['article.rb', 'legacy/*'],
+          include_indexes: false
         )
       end
     end
@@ -78,6 +81,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when include_indexes is not a boolean' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "include_indexes: maybe\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'include_indexes must be true or false'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -90,6 +105,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
         content = File.read(path)
         expect(content).to include('annotation_position: top')
         expect(content).to include('exclude_model_files: []')
+        expect(content).to include('include_indexes: true')
       end
     end
   end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         env_file_path: 'config/environment.rb',
         model_dir: 'app/models',
         route_file_path: 'config/routes.rb',
-        annotation_position: 'top'
+        annotation_position: 'top',
+        exclude_model_files: []
       )
     end
 
@@ -24,6 +25,9 @@ RSpec.describe AwesomeAnnotate::Configuration do
           model_dir: spec/mock
           route_file_path: spec/mock/routes.rb
           annotation_position: bottom
+          exclude_model_files:
+            - article.rb
+            - legacy/*
           unknown_option: ignored
         YAML
 
@@ -33,7 +37,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
           env_file_path: 'spec/mock/config.rb',
           model_dir: 'spec/mock',
           route_file_path: 'spec/mock/routes.rb',
-          annotation_position: 'bottom'
+          annotation_position: 'bottom',
+          exclude_model_files: ['article.rb', 'legacy/*']
         )
       end
     end
@@ -61,6 +66,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when exclude_model_files is not an array' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "exclude_model_files: article.rb\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'exclude_model_files must be an array'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -70,7 +87,9 @@ RSpec.describe AwesomeAnnotate::Configuration do
 
         described_class.create(path)
 
-        expect(File.read(path)).to include('annotation_position: top')
+        content = File.read(path)
+        expect(content).to include('annotation_position: top')
+        expect(content).to include('exclude_model_files: []')
       end
     end
   end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
       expect(config.options).to eq(
         env_file_path: 'config/environment.rb',
         model_dir: 'app/models',
-        route_file_path: 'config/routes.rb'
+        route_file_path: 'config/routes.rb',
+        annotation_position: 'top'
       )
     end
 
@@ -22,6 +23,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
           env_file_path: spec/mock/config.rb
           model_dir: spec/mock
           route_file_path: spec/mock/routes.rb
+          annotation_position: bottom
           unknown_option: ignored
         YAML
 
@@ -30,7 +32,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         expect(config.options).to eq(
           env_file_path: 'spec/mock/config.rb',
           model_dir: 'spec/mock',
-          route_file_path: 'spec/mock/routes.rb'
+          route_file_path: 'spec/mock/routes.rb',
+          annotation_position: 'bottom'
         )
       end
     end
@@ -46,6 +49,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when annotation_position is invalid' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "annotation_position: middle\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'annotation_position must be one of: top, bottom'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -55,7 +70,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
 
         described_class.create(path)
 
-        expect(File.read(path)).to include('model_dir: app/models')
+        expect(File.read(path)).to include('annotation_position: top')
       end
     end
   end

--- a/spec/lib/awesome_annotate/configuration_spec.rb
+++ b/spec/lib/awesome_annotate/configuration_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
         exclude_model_files: [],
         include_indexes: true,
         exclude_columns: [],
-        include_column_defaults: true
+        include_column_defaults: true,
+        exclude_routes: []
       )
     end
 
@@ -36,6 +37,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
             - encrypted_password
             - reset_password_token
           include_column_defaults: false
+          exclude_routes:
+            - '*private_policy*'
           unknown_option: ignored
         YAML
 
@@ -49,7 +52,8 @@ RSpec.describe AwesomeAnnotate::Configuration do
           exclude_model_files: ['article.rb', 'legacy/*'],
           include_indexes: false,
           exclude_columns: %w[encrypted_password reset_password_token],
-          include_column_defaults: false
+          include_column_defaults: false,
+          exclude_routes: ['*private_policy*']
         )
       end
     end
@@ -125,6 +129,18 @@ RSpec.describe AwesomeAnnotate::Configuration do
         )
       end
     end
+
+    it 'raises when exclude_routes is not an array' do
+      Dir.mktmpdir do |dir|
+        path = File.join(dir, 'awesome_annotate.yml')
+        File.write(path, "exclude_routes: private_policy\n")
+
+        expect { described_class.load(path) }.to raise_error(
+          ArgumentError,
+          'exclude_routes must be an array'
+        )
+      end
+    end
   end
 
   describe '.create' do
@@ -140,6 +156,7 @@ RSpec.describe AwesomeAnnotate::Configuration do
         expect(content).to include('include_indexes: true')
         expect(content).to include('exclude_columns: []')
         expect(content).to include('include_column_defaults: true')
+        expect(content).to include('exclude_routes: []')
       end
     end
   end

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe AwesomeAnnotate::Model do
   let(:env_file_path) { 'spec/mock/config.rb' }
   let(:model_dir) { 'spec/mock' }
   let(:annotation_position) { 'top' }
+  let(:exclude_model_files) { [] }
   let(:annotate_model) do
     described_class.new(
       env_file_path: env_file_path,
       model_dir: model_dir,
-      annotation_position: annotation_position
+      annotation_position: annotation_position,
+      exclude_model_files: exclude_model_files
     )
   end
 
@@ -124,6 +126,24 @@ RSpec.describe AwesomeAnnotate::Model do
       after do
         file_reset("#{model_dir}/user.rb")
         file_reset("#{model_dir}/article.rb")
+      end
+
+      context 'when exclude_model_files is set' do
+        let(:exclude_model_files) { ['article.rb'] }
+
+        it 'skips excluded model files during discovery' do
+          expect do
+            annotate_model.annotate_all
+          end.to output(/annotate users table columns/).to_stdout
+
+          user_content = File.read("#{model_dir}/user.rb")
+          article_content = File.read("#{model_dir}/article.rb")
+
+          expect(user_content).to include '# Table name: users'
+          expect(article_content).not_to include '# == AwesomeAnnotate: columns'
+        end
+
+        after { file_reset("#{model_dir}/user.rb") }
       end
     end
   end

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -64,6 +64,29 @@ RSpec.describe AwesomeAnnotate::Model do
           end
         end
 
+        context 'when include_indexes is false' do
+          let(:annotate_model) do
+            described_class.new(
+              env_file_path: env_file_path,
+              model_dir: model_dir,
+              annotation_position: annotation_position,
+              exclude_model_files: exclude_model_files,
+              include_indexes: false
+            )
+          end
+
+          it 'does not write index annotations' do
+            expect do
+              annotate_model.annotate('user')
+            end.to output(%r{annotate users table columns in spec/mock/user\.rb}).to_stdout
+
+            file_content = File.read("#{model_dir}/user.rb")
+            expect(file_content).to include '#  email      :string   not null, default("")'
+            expect(file_content).not_to include '# Indexes'
+            expect(file_content).not_to include '#  (email)       UNIQUE, index_users_on_email'
+          end
+        end
+
         after { file_reset("#{model_dir}/user.rb") }
       end
 

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -8,7 +8,14 @@ require 'active_record'
 RSpec.describe AwesomeAnnotate::Model do
   let(:env_file_path) { 'spec/mock/config.rb' }
   let(:model_dir) { 'spec/mock' }
-  let(:annotate_model) { described_class.new(env_file_path: env_file_path, model_dir: model_dir) }
+  let(:annotation_position) { 'top' }
+  let(:annotate_model) do
+    described_class.new(
+      env_file_path: env_file_path,
+      model_dir: model_dir,
+      annotation_position: annotation_position
+    )
+  end
 
   describe '#annotate' do
     context 'when env file path exists' do
@@ -37,6 +44,22 @@ RSpec.describe AwesomeAnnotate::Model do
           expect(file_content.scan('# == AwesomeAnnotate: columns').size).to eq 1
           expect(file_content.scan('# == /AwesomeAnnotate: columns').size).to eq 1
           expect(file_content.scan('# == Schema Information').size).to eq 1
+        end
+
+        context 'when annotation_position is bottom' do
+          let(:annotation_position) { 'bottom' }
+
+          it 'writes the annotation at the bottom of the model file' do
+            expect do
+              annotate_model.annotate('user')
+            end.to output(%r{annotate users table columns in spec/mock/user\.rb}).to_stdout
+
+            file_content = File.read("#{model_dir}/user.rb")
+            class_position = file_content.index('class User < ActiveRecord::Base')
+            annotation_position = file_content.index('# == AwesomeAnnotate: columns')
+            expect(class_position).to be < annotation_position
+            expect(file_content).to end_with("# == /AwesomeAnnotate: columns\n\n")
+          end
         end
 
         after { file_reset("#{model_dir}/user.rb") }

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -109,6 +109,28 @@ RSpec.describe AwesomeAnnotate::Model do
           end
         end
 
+        context 'when include_column_defaults is false' do
+          let(:annotate_model) do
+            described_class.new(
+              env_file_path: env_file_path,
+              model_dir: model_dir,
+              annotation_position: annotation_position,
+              exclude_model_files: exclude_model_files,
+              include_column_defaults: false
+            )
+          end
+
+          it 'does not write column default details' do
+            expect do
+              annotate_model.annotate('user')
+            end.to output(%r{annotate users table columns in spec/mock/user\.rb}).to_stdout
+
+            file_content = File.read("#{model_dir}/user.rb")
+            expect(file_content).to include '#  email      :string   not null'
+            expect(file_content).not_to include 'default("")'
+          end
+        end
+
         after { file_reset("#{model_dir}/user.rb") }
       end
 

--- a/spec/lib/awesome_annotate/model_spec.rb
+++ b/spec/lib/awesome_annotate/model_spec.rb
@@ -87,6 +87,28 @@ RSpec.describe AwesomeAnnotate::Model do
           end
         end
 
+        context 'when exclude_columns is set' do
+          let(:annotate_model) do
+            described_class.new(
+              env_file_path: env_file_path,
+              model_dir: model_dir,
+              annotation_position: annotation_position,
+              exclude_model_files: exclude_model_files,
+              exclude_columns: ['email']
+            )
+          end
+
+          it 'does not write excluded columns' do
+            expect do
+              annotate_model.annotate('user')
+            end.to output(%r{annotate users table columns in spec/mock/user\.rb}).to_stdout
+
+            file_content = File.read("#{model_dir}/user.rb")
+            expect(file_content).to include '#  id         :integer  not null, primary key'
+            expect(file_content).not_to include '#  email'
+          end
+        end
+
         after { file_reset("#{model_dir}/user.rb") }
       end
 

--- a/spec/lib/awesome_annotate/route_spec.rb
+++ b/spec/lib/awesome_annotate/route_spec.rb
@@ -67,6 +67,26 @@ RSpec.describe AwesomeAnnotate::Route do
           end
         end
 
+        context 'when exclude_routes is set' do
+          let(:annotate_model) do
+            described_class.new(
+              env_file_path: env_file_path,
+              route_file_path: route_file_path,
+              annotation_position: annotation_position,
+              exclude_routes: ['*private_policy*']
+            )
+          end
+
+          it 'does not write excluded route lines' do
+            expect { annotate_model.annotate }.to output(%r{annotate routes in spec/mock/routes\.rb}).to_stdout
+
+            file_content = File.read(route_file_path)
+            expect(file_content).to include 'home#top'
+            expect(file_content).to include 'home#policy'
+            expect(file_content).not_to include 'home#private_policy'
+          end
+        end
+
         after { file_reset(route_file_path) }
       end
 

--- a/spec/lib/awesome_annotate/route_spec.rb
+++ b/spec/lib/awesome_annotate/route_spec.rb
@@ -8,7 +8,14 @@ require 'active_record'
 RSpec.describe AwesomeAnnotate::Route do
   let(:env_file_path) { 'spec/mock/config.rb' }
   let(:route_file_path) { 'spec/mock/routes.rb' }
-  let(:annotate_model) { described_class.new(env_file_path: env_file_path, route_file_path: route_file_path) }
+  let(:annotation_position) { 'top' }
+  let(:annotate_model) do
+    described_class.new(
+      env_file_path: env_file_path,
+      route_file_path: route_file_path,
+      annotation_position: annotation_position
+    )
+  end
   let(:routes_message) { File.readlines('spec/support/routes_message.txt').join }
 
   def parse_routes(routes)
@@ -44,6 +51,20 @@ RSpec.describe AwesomeAnnotate::Route do
           expect(file_content.scan('# == AwesomeAnnotate: routes').size).to eq 1
           expect(file_content.scan('# == /AwesomeAnnotate: routes').size).to eq 1
           expect(file_content.scan('#---This is route annotate---').size).to eq 1
+        end
+
+        context 'when annotation_position is bottom' do
+          let(:annotation_position) { 'bottom' }
+
+          it 'writes the annotation at the bottom of the route file' do
+            expect { annotate_model.annotate }.to output(%r{annotate routes in spec/mock/routes\.rb}).to_stdout
+
+            file_content = File.read(route_file_path)
+            route_position = file_content.index('Rails.application.routes.draw do')
+            annotation_position = file_content.index('# == AwesomeAnnotate: routes')
+            expect(route_position).to be < annotation_position
+            expect(file_content).to end_with("# == /AwesomeAnnotate: routes\n\n")
+          end
         end
 
         after { file_reset(route_file_path) }


### PR DESCRIPTION
add 
This pull request introduces a configuration system to AwesomeAnnotate, allowing users to customize annotation behavior via a YAML config file. It adds a new `init` command to generate this file, updates CLI commands to use configuration options, and extends annotation features to support new exclusion and formatting options for both models and routes. Tests are also added to verify configuration-driven behavior.

**Configuration system and CLI integration:**

* Introduced a new `AwesomeAnnotate::Configuration` class that loads options from `config/initializers/awesome_annotate.yml`, with validation and defaults for all supported settings. A new `init` command creates this file with documentation and sensible defaults. All CLI commands now instantiate annotators with these options, enabling project-wide customization. [[1]](diffhunk://#diff-aa64ab669b86019445bdda142e6f9d243b0d8cc0ee1bb3b7d8897221bd66493cR1-R112) [[2]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057L13-R44) [[3]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057L45-R88) [[4]](diffhunk://#diff-3aca33563baac5a8be8929142a66a8ad21680b89717bd2e96ba87ba7d2fbb057R97-R110) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R94-R127)

* Added tests to ensure CLI commands pass configuration options to model and route annotators, and that the `init` command creates or preserves the config file as expected.

**Model annotation enhancements:**

* Model annotator now supports new config options: `annotation_position` (top or bottom of file), `exclude_model_files` (glob patterns), `include_indexes`, `exclude_columns`, and `include_column_defaults`. These are respected during annotation and removal, allowing fine-grained control over schema output. [[1]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eR21-R25) [[2]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL78-R83) [[3]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL89-R97) [[4]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL107-R116) [[5]](diffhunk://#diff-2fc046f557825ee535aa21cabd356265a247dcefe3e1f71f81e0e15888ac8ce5L8-R29) [[6]](diffhunk://#diff-2fc046f557825ee535aa21cabd356265a247dcefe3e1f71f81e0e15888ac8ce5R39-R45) [[7]](diffhunk://#diff-2fc046f557825ee535aa21cabd356265a247dcefe3e1f71f81e0e15888ac8ce5L47-R64)

**Route annotation enhancements:**

* Route annotator now supports `annotation_position` and `exclude_routes` options, letting users control annotation placement and filter out specific routes from annotation blocks. [[1]](diffhunk://#diff-3a2deaf175160ffb476ff95e93a2bc71686d193b1e88d0e2e86307db2fd3985cR18-R19) [[2]](diffhunk://#diff-3a2deaf175160ffb476ff95e93a2bc71686d193b1e88d0e2e86307db2fd3985cL53-R55) [[3]](diffhunk://#diff-3a2deaf175160ffb476ff95e93a2bc71686d193b1e88d0e2e86307db2fd3985cR64-R74)

**Internal refactoring:**

* Refactored CLI and annotation code to centralize configuration loading and option passing, and updated annotation block logic to support configurable insertion position. [[1]](diffhunk://#diff-eb3ff95f9499b079ab90968c800dc83314551588c7972facef49dab3ae05ad51L7-R12) [[2]](diffhunk://#diff-eb3ff95f9499b079ab90968c800dc83314551588c7972facef49dab3ae05ad51L39-R45) F5cee09dL2R2, [[3]](diffhunk://#diff-0630bacd61c1a3651d759cc10ecb44afa067e14dab4d8c1781b97cc94a4a9bf7R5) [[4]](diffhunk://#diff-03716e08e887623a16e2b536e22f69b93f2d40fdc99187db466bd2b35543e94eL134-R139)

These changes make AwesomeAnnotate much more flexible and easier to tailor to non-standard Rails project structures and custom annotation requirements.